### PR TITLE
Remove addToBookshelf

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -196,8 +196,7 @@ $(document).ready(function() {
                 mediaURL: url,
                 videoQuality: videoQuality,
                 maxVideos: maxVideos,
-                maxVideosSize: maxVideosSize,
-                addToBookshelf: addToBookshelf
+                maxVideosSize: maxVideosSize
             },
             success: function(response) {
                 // Handle success response here
@@ -265,11 +264,6 @@ $(document).ready(function() {
         } else {
             $("#maxVideos").prop("disabled", false);
         }
-    });
-
-    // Handle change event for the add to bookshelf checkbox
-    $("#addToBookshelf").change(function() {
-        // Handle change event
     });
 
     // Function to validate URL

--- a/cps/templates/modal_dialogs.html
+++ b/cps/templates/modal_dialogs.html
@@ -200,14 +200,6 @@
                 <input type="number" class="form-control" id="maxVideosSize" name="maxVideosSize" min="1" max="5000">
               </div>
             </div>
-            <!-- Add All Videos to Bookshelf -->
-            <div class="form-group">
-              <div class="col-sm-offset-2 col-sm-10">
-                <label class="checkbox-inline">
-                  <input type="checkbox" id="addToBookshelf" name="addToBookshelf"> Add All Videos to Bookshelf
-                </label>
-              </div>
-            </div>
         </form>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
When a collection is submitted, for example a playlist url, a bookshelf is automatically added. This remove the redundant option to add one.