### PR TITLE
Clarify cps/constants.py and scripts/lb-wrapper [& refine URL validation, to accept http:// legacy URLs w/o SSL/TLS]

### DIFF
--- a/cps/constants.py
+++ b/cps/constants.py
@@ -44,8 +44,9 @@ TRANSLATIONS_DIR    = os.path.join(BASE_DIR, 'cps', 'translations')
 DEFAULT_CACHE_DIR   = os.path.join(BASE_DIR, 'cps', 'cache')
 CACHE_DIR           = os.environ.get('CACHE_DIR', DEFAULT_CACHE_DIR)
 
-# Database dir for media files downloaded from the internet
-SURVEY_DB_FILE    = "/library/downloads/calibre-web/survey.db"
+# 2023-11-15: See scripts/lb-wrapper which uses xklb's 'lb tubeadd ...' to save
+# an initial metadata manifest (prior to downloading videos or media) here:
+SURVEY_DB_FILE      = "/library/downloads/calibre-web/survey.db"
 
 if HOME_CONFIG:
     home_dir = os.path.join(os.path.expanduser("~"), ".calibre-web")

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -179,6 +179,7 @@ $(document).ready(function() {
         maxVideos = maxVideos === "" ? 0 : parseInt(maxVideos);
         maxVideosSize = maxVideosSize === "" ? 0 : parseInt(maxVideosSize);
 
+        /*
         // Check if the input URL is a valid URL
         // First check if URL starts with https:// if not, prepend it
         url = url.startsWith("https://") ? url : "https://" + url;
@@ -186,6 +187,11 @@ $(document).ready(function() {
             alert("Invalid URL");
             return;
         }
+        */
+
+        // Prepend https:// if URL doesn't begin with http:// or https://
+        // As xklb requires: https://github.com/iiab/calibre-web/pull/44
+        url = /^https?:\/\//.test(url) ? url : "https://" + url;
 
         var currentURL = new URL(window.location.href);
         currentURL.pathname = currentURL.pathname.split('/').slice(1, 2).join('/') + "/media";
@@ -272,13 +278,15 @@ $(document).ready(function() {
         }
     });
 
+    /*
     // Function to validate URL
     function isValidURL(url) {
-        // Regex to validate URL (should be any url starting with https://)
+        // Regex to validate URL (should be any url starting with http:// or https://)
         var urlPattern = /^https?:\/\//i;
         // Check if the URL matches the pattern
         return urlPattern.test(url);
     }
+    */
 
 });
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -26,9 +26,11 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-# 2023-11-15: Good enough for now, URL validation likely to improve soon!
+# URL validation already taken care of by cps/static/js/main.js Line ~194,
+# which prepends https:// if URL doesn't already begin with http:// or https://
+# (So test below is not really nec, except to enforce the above, with logging.)
 if [[ ! ${URL} =~ ^http[s]?:// ]]; then
-    log 'Invalid URL: xklb commands require URLs begin with "https://" or "http://"'
+    log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
     exit 1
 fi
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -2,10 +2,10 @@
 
 # Configuration
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
-LOG_FILE="/var/log/xklb.log"
-SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 URL="$1"
+LOG_FILE="/var/log/xklb.log"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
@@ -15,22 +15,19 @@ log() {
 }
 
 # Check if xklb is installed
-if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null
-then
+if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null; then
     log "xklb could not be found. Please install xklb and try again."
     exit 1
 fi
 
 # Check if the user provided any arguments
-if [ $# -eq 0 ]
-then
+if [ $# -eq 0 ]; then
     log "No arguments provided. Please provide a URL to download."
     exit 1
 fi
 
-# Validate URL
-if [[ ! ${URL} =~ ^http[s]?:// ]]
-then
+# URLs must begin with "https://" or "http://" (for what reason?)
+if [[ ! ${URL} =~ ^http[s]?:// ]]; then
     log "Invalid URL provided. Please provide a valid URL to download."
     exit 1
 fi
@@ -48,5 +45,3 @@ if [ $? -ne 0 ]; then
 fi
 
 log "Download completed successfully."
-
-exit 0

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -2,12 +2,12 @@
 
 # Configuration
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
-TMP_DOWNLOADS_PATH="/library/downloads/calibre-web"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 LOG_FILE="/var/log/xklb.log"
-SURVEY_DB_FILE="${TMP_DOWNLOADS_PATH}/survey.db"
+SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 URL="$1"
 
-mkdir -p ${TMP_DOWNLOADS_PATH}
+mkdir -p ${TMP_DOWNLOADS_DIR}
 
 # Function to log messages
 log() {
@@ -37,9 +37,9 @@ fi
 
 log "Moving ${SURVEY_DB_FILE} aside if it already exists."
 mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_PATH} --extractor-config "writethumbnail=True" --video ${URL} --verbose"
+log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --extractor-config "writethumbnail=True" --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
-        ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_PATH} --extractor-config "writethumbnail=True" \
+        ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --extractor-config "writethumbnail=True" \
         --video ${URL} --verbose)
 
 if [ $? -ne 0 ]; then

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -26,9 +26,9 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-# URLs must begin with "https://" or "http://" (for what reason?)
+# 2023-11-15: Good enough for now, URL validation likely to improve soon!
 if [[ ! ${URL} =~ ^http[s]?:// ]]; then
-    log "Invalid URL provided. Please provide a valid URL to download."
+    log 'Invalid URL: xklb commands require URLs begin with "https://" or "http://"'
     exit 1
 fi
 


### PR DESCRIPTION
@deldesir: ok to tighten up a bit for readability?

Can you remind if/why `if [[ ! ${URL} =~ ^http[s]?:// ]]` is truly necessary in lb-wrapper?  (Do xklb and/or yt-dlp fail if $URL doesn't begin with "http://" or "https://" ?)