### PR TITLE
Sort formats [720p codec, viewing bitrate ~2 Mbit/s]

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -36,7 +36,7 @@ fi
 
 log "Moving ${SURVEY_DB_FILE} aside if it already exists."
 mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format='bestvideo[height<=720][vcodec=vp9]+bestaudio/best[height<=720][vcodec=vp9]' --video ${URL} --verbose"
+log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail--format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
         ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
         --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose)

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -39,7 +39,7 @@ mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
 log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format='bestvideo[height<=720][vcodec=vp9]+bestaudio/best[height<=720][vcodec=vp9]' --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
         ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
-        --format='bestvideo[height<=720][vcodec=vp9]+bestaudio/best[height<=720][vcodec=vp9]' --video ${URL} --verbose)
+        --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose)
 
 if [ $? -ne 0 ]; then
     log "An error occurred while running the command. Output: ${OUTPUT}"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -36,10 +36,10 @@ fi
 
 log "Moving ${SURVEY_DB_FILE} aside if it already exists."
 mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose"
+log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format-sort='res:720,tbr~2000' --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
         ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
-        --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose)
+        --format-sort='res:720,tbr~2000' --video ${URL} --verbose)
 
 if [ $? -ne 0 ]; then
     log "An error occurred while running the command. Output: ${OUTPUT}"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -36,7 +36,7 @@ fi
 
 log "Moving ${SURVEY_DB_FILE} aside if it already exists."
 mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail--format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose"
+log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
         ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
         --prefer-free-formats --format='best' --format-sort='res:720,tbr~2000' --video ${URL} --verbose)


### PR DESCRIPTION
This is based on this [discussion ](https://github.com/yt-dlp/yt-dlp/issues/5169) and designed to download the best available format that is free (i.e webm), has a resolution of 720p, and has an average bitrate of audio and video up to 2000 kbps. It allows for flexibility by considering various formats but still prioritizes quality aspects like resolution and bitrate.

`--prefer-free-formats`: Prefer video formats with free containers over non-free ones of same quality

`--format='best'`: This option specifies the initial format to consider. In this case, it's set to 'best', which tells yt-dlp to initially consider the best available quality for both video and audio.

 `--format-sort='res:720,tbr~2000'`: This option instructs yt-dlp to sort the available formats based on a 720p resolution (res:720) and the average of audio and video bitrate up to 2000 kbps (tbr~2000). 