### PR TITLE
Create scripts/lb-wrapper.greedy à la 'yt-dlp dl --format-sort size' [and refactor /usr/local/bin/lb-wrapper]

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Configuration
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 URL="$1"
 LOG_FILE="/var/log/xklb.log"
@@ -14,13 +13,11 @@ log() {
     echo "$(date +'%Y-%m-%d %H:%M:%S') - $1" | tee -a ${LOG_FILE}
 }
 
-# Check if xklb is installed
 if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null; then
     log "xklb could not be found. Please install xklb and try again."
     exit 1
 fi
 
-# Check if the user provided any arguments
 if [ $# -eq 0 ]; then
     log "No arguments provided. Please provide a URL to download."
     exit 1
@@ -34,12 +31,13 @@ if [[ ! ${URL} =~ ^http[s]?:// ]]; then
     exit 1
 fi
 
-log "Moving ${SURVEY_DB_FILE} aside if it already exists."
-mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
+if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z); then
+    log "Old ${SURVEY_DB_FILE} moved aside."
+fi
 log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format best --format-sort 'tbr~1000' --video ${URL} --verbose"
 OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
-        ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
-        --format best --format-sort 'tbr~1000' --video ${URL} --verbose)
+    ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
+    --format best --format-sort 'tbr~1000' --video ${URL} --verbose)
 
 if [ $? -ne 0 ]; then
     log "An error occurred while running the command. Output: ${OUTPUT}"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -5,7 +5,8 @@ XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 URL="$1"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
-XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format best --format-sort 'tbr~1000' --video ${URL} --verbose"
+FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
+XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail ${FORMAT_OPTIONS} --video ${URL} --verbose"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -2,9 +2,9 @@
 
 LOG_FILE="/var/log/xklb.log"
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 URL="$1"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
 XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail ${FORMAT_OPTIONS} --video ${URL} --verbose"
 
@@ -34,7 +34,7 @@ fi
 #     exit 1
 # fi
 
-if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z); then
+if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
     log "Old ${SURVEY_DB_FILE} moved aside."
 fi
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -1,19 +1,20 @@
 #!/bin/bash
 
-XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
-URL="$1"
 LOG_FILE="/var/log/xklb.log"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
+URL="$1"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format best --format-sort 'tbr~1000' --video ${URL} --verbose"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
-# Function to log messages
+# Function to log messages (and errors especially!)
 log() {
     echo "$(date +'%Y-%m-%d %H:%M:%S') - $1" | tee -a ${LOG_FILE}
 }
 
-if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null; then
+if ! command -v "${XKLB_EXECUTABLE}"; then
     log "xklb could not be found. Please install xklb and try again."
     exit 1
 fi
@@ -25,23 +26,21 @@ fi
 
 # URL validation already taken care of by cps/static/js/main.js Line ~194,
 # which prepends https:// if URL doesn't already begin with http:// or https://
-# (So test below is not really nec, except to enforce the above, with logging.)
-if [[ ! ${URL} =~ ^http[s]?:// ]]; then
-    log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
-    exit 1
-fi
+# (Test below meant well, to enforce with logging, but violates "SSOT" --
+# preconditions should be enforced in 1 single place if possible!)
+# if [[ ! ${URL} =~ ^http[s]?:// ]]; then
+#     log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
+#     exit 1
+# fi
 
 if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z); then
     log "Old ${SURVEY_DB_FILE} moved aside."
 fi
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --format best --format-sort 'tbr~1000' --video ${URL} --verbose"
-OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
-    ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
-    --format best --format-sort 'tbr~1000' --video ${URL} --verbose)
 
-if [ $? -ne 0 ]; then
+log "Running command: ${XKLB_FULL_CMD}"
+if OUTPUT=$(${XKLB_FULL_CMD}); then
+    log "Download completed successfully."
+else
     log "An error occurred while running the command. Output: ${OUTPUT}"
     exit 1
 fi
-
-log "Download completed successfully."

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -39,7 +39,7 @@ if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
 fi
 
 log "Running command: ${XKLB_FULL_CMD}"
-if OUTPUT=$(${XKLB_FULL_CMD}); then
+if OUTPUT=$(eval "${XKLB_FULL_CMD}"); then
     log "Download completed successfully."
 else
     log "An error occurred while running the command. Output: ${OUTPUT}"

--- a/scripts/lb-wrapper.greedy
+++ b/scripts/lb-wrapper.greedy
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Configuration
+XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
+URL="$1"
+LOG_FILE="/var/log/xklb.log"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
+
+mkdir -p ${TMP_DOWNLOADS_DIR}
+
+# Function to log messages
+log() {
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - $1" | tee -a ${LOG_FILE}
+}
+
+# Check if xklb is installed
+if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null; then
+    log "xklb could not be found. Please install xklb and try again."
+    exit 1
+fi
+
+# Check if the user provided any arguments
+if [ $# -eq 0 ]; then
+    log "No arguments provided. Please provide a URL to download."
+    exit 1
+fi
+
+# URL validation already taken care of by cps/static/js/main.js Line ~194,
+# which prepends https:// if URL doesn't already begin with http:// or https://
+# (So test below is not really nec, except to enforce the above, with logging.)
+if [[ ! ${URL} =~ ^http[s]?:// ]]; then
+    log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
+    exit 1
+fi
+
+log "Moving ${SURVEY_DB_FILE} aside if it already exists."
+mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
+log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --video ${URL} --verbose"
+OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
+        ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
+        --video ${URL} --verbose)
+
+if [ $? -ne 0 ]; then
+    log "An error occurred while running the command. Output: ${OUTPUT}"
+    exit 1
+fi
+
+log "Download completed successfully."

--- a/scripts/lb-wrapper.greedy
+++ b/scripts/lb-wrapper.greedy
@@ -1,26 +1,29 @@
 #!/bin/bash
 
-# Configuration
-XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
-URL="$1"
+# Drop-in replacement for /usr/local/bin/lb-wrapper downloads largest possible
+# HD-style / UltraHD videos, to try to force out-of-memory "502 Bad Gateway"
+# for testing of issues like: https://github.com/iiab/calibre-web/issues/37
+
 LOG_FILE="/var/log/xklb.log"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
+URL="$1"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+FORMAT_OPTIONS="--format-sort size"
+XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail ${FORMAT_OPTIONS} --video ${URL} --verbose"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
-# Function to log messages
+# Function to log messages (and errors especially!)
 log() {
     echo "$(date +'%Y-%m-%d %H:%M:%S') - $1" | tee -a ${LOG_FILE}
 }
 
-# Check if xklb is installed
-if ! command -v "${XKLB_EXECUTABLE}" &> /dev/null; then
+if ! command -v "${XKLB_EXECUTABLE}"; then
     log "xklb could not be found. Please install xklb and try again."
     exit 1
 fi
 
-# Check if the user provided any arguments
 if [ $# -eq 0 ]; then
     log "No arguments provided. Please provide a URL to download."
     exit 1
@@ -28,22 +31,21 @@ fi
 
 # URL validation already taken care of by cps/static/js/main.js Line ~194,
 # which prepends https:// if URL doesn't already begin with http:// or https://
-# (So test below is not really nec, except to enforce the above, with logging.)
-if [[ ! ${URL} =~ ^http[s]?:// ]]; then
-    log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
-    exit 1
+# (Test below meant well, to enforce with logging, but violates "SSOT" --
+# preconditions should be enforced in 1 single place if possible!)
+# if [[ ! ${URL} =~ ^http[s]?:// ]]; then
+#     log 'Invalid URL: xklb commands require URLs begin with "http://" or "https://"'
+#     exit 1
+# fi
+
+if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z); then
+    log "Old ${SURVEY_DB_FILE} moved aside."
 fi
 
-log "Moving ${SURVEY_DB_FILE} aside if it already exists."
-mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) || true
-log "Running command: ${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail --video ${URL} --verbose"
-OUTPUT=$(${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && \
-        ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail \
-        --video ${URL} --verbose)
-
-if [ $? -ne 0 ]; then
+log "Running command: ${XKLB_FULL_CMD}"
+if OUTPUT=$(${XKLB_FULL_CMD}); then
+    log "Download completed successfully."
+else
     log "An error occurred while running the command. Output: ${OUTPUT}"
     exit 1
 fi
-
-log "Download completed successfully."

--- a/scripts/lb-wrapper.greedy
+++ b/scripts/lb-wrapper.greedy
@@ -43,7 +43,7 @@ if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
 fi
 
 log "Running command: ${XKLB_FULL_CMD}"
-if OUTPUT=$(${XKLB_FULL_CMD}); then
+if OUTPUT=$(eval "${XKLB_FULL_CMD}"); then
     log "Download completed successfully."
 else
     log "An error occurred while running the command. Output: ${OUTPUT}"

--- a/scripts/lb-wrapper.greedy
+++ b/scripts/lb-wrapper.greedy
@@ -6,9 +6,9 @@
 
 LOG_FILE="/var/log/xklb.log"
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
 URL="$1"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 FORMAT_OPTIONS="--format-sort size"
 XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} --verbose && ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --write-thumbnail ${FORMAT_OPTIONS} --video ${URL} --verbose"
 
@@ -38,7 +38,7 @@ fi
 #     exit 1
 # fi
 
-if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z); then
+if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
     log "Old ${SURVEY_DB_FILE} moved aside."
 fi
 


### PR DESCRIPTION
1) This PR aims to help testing (of yt-dlp etc) by allowing for manual copying  of `/usr/local/calibre-web-py3/scripts/lb-wrapper.greedy` to `/usr/local/bin/lb-wrapper ` in order to...

2) Force downloading of very large videos e.g. for OOM (out-of-memory) during testing of things like:

- #37
- PR #51
- #53
- PR #57
- PR #60
- PR #62
- PR #63