### PR TITLE
Trim whitespace

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -191,6 +191,7 @@ $(document).ready(function() {
 
         // Prepend https:// if URL doesn't begin with http:// or https://
         // As xklb requires: https://github.com/iiab/calibre-web/pull/44
+        url = url.trim();
         url = /^https?:\/\//.test(url) ? url : "https://" + url;
 
         var currentURL = new URL(window.location.href);


### PR DESCRIPTION
Trim whitespace from url. A whitespace before the url would cause a download failure. Tested on Ubuntu 24.04 (10.8.0.18).