### PR TITLE
Find webp file [thumbnail/cover/poster for MP4; not just WebM ?]

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -269,7 +269,7 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 # find cover file
                 if os.path.isdir(os.path.dirname(row['path'])):
                     for file in os.listdir(os.path.dirname(row['path'])):
-                        if os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
+                        if file.endswith('.webp') and os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
                             cover_file_path = os.path.join(os.path.dirname(row['path']), file)
                             break
                 else:


### PR DESCRIPTION
This PR builds upon #65 that would find the relevant thumbnail files when there are several versions of the same file in the same book directory. However #65 would fail on some occasions because the logic was based on comparing the files to find the one with the same "filename", without considering the extension. This PR strengthen it by  comparing only files with the .webp extension. 