### PR TITLE
Pull full description text from 'captions' table

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -261,7 +261,6 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
             if row is not None:
                 title = row['title']
                 author = row['path'].split('/calibre-web/')[1].split('/')[1].replace('_', ' ')
-                description = row['description']
                 publisher = row['path'].split('/calibre-web/')[1].split('/')[0].replace('_', ' ')
                 # example of time_uploaded: 1696464000
                 pubdate = row['time_uploaded']
@@ -275,6 +274,9 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 else:
                     log.warning('Cannot find .webp file, using default cover')
                     cover_file_path = os.path.splitext(tmp_file_path)[0] + '.cover.jpg'
+                c.execute("SELECT * FROM captions WHERE media_id=?", (1,))
+                row = c.fetchone()
+                description = row['text'] if row is not None else ''
                 meta = BookMeta(
                     file_path=tmp_file_path,
                     extension=original_file_extension,


### PR DESCRIPTION
This PR fixes #67 by reading the text column from the captions table instead of the description column from the media table. Tested on Ubuntu 24.04 (10.8.0.18)