### PR TITLE
Support PNG, WEBP, GIF, JPG covers/thumbnails

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -268,7 +268,7 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 # find cover file
                 if os.path.isdir(os.path.dirname(row['path'])):
                     for file in os.listdir(os.path.dirname(row['path'])):
-                        if file.endswith('.webp') and os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
+                        if file.lower().endswith(('.webp', '.jpg', '.png', '.gif')) and os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
                             cover_file_path = os.path.join(os.path.dirname(row['path']), file)
                             break
                 else:


### PR DESCRIPTION
This PR makes thumbnail code resilient to work with PNG, WEBP, GIF, JPG.  Tested on Ubuntu 24.04 (10.8.0.18) with a random Vimeo link (Vimeo thumbnails are named _cover.jpg_).

_Requested by @holta in https://github.com/iiab/calibre-web/issues/69#issuecomment-1863313716_
            