### PR TITLE
Remove advanced settings from "Download" modal dialog

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -150,34 +150,9 @@ $(document).ready(function() {
         }
     }
 
-    // Function to toggle advanced options visibility
-    function toggleAdvancedOptions() {
-        var advancedOptions = $("#advancedOptions");
-        if (advancedOptions.is(":visible")) {
-            advancedOptions.hide();
-            $("#advancedOptionsToggle").text("Show advanced options")
-        } else {
-            advancedOptions.show();
-            $("#advancedOptionsToggle").text("Hide advanced options")
-        }
-    }
-
-    // Handle click event for the advanced options toggle
-    $("#advancedOptionsToggle").click(function(event) {
-        event.preventDefault();
-        toggleAdvancedOptions();
-    });
-
     // Function to initiate the media download AJAX request
     function initiateMediaDownload() {
         var url = $("#mediaURL").val();
-        var videoQuality = $("input[name='videoQuality']:checked").val();
-        var maxVideos = $("#maxVideos").val();
-        var maxVideosSize = $("#maxVideosSize").val();
-
-        // Set empty number values to zero
-        maxVideos = maxVideos === "" ? 0 : parseInt(maxVideos);
-        maxVideosSize = maxVideosSize === "" ? 0 : parseInt(maxVideosSize);
 
         /*
         // Check if the input URL is a valid URL
@@ -203,10 +178,7 @@ $(document).ready(function() {
             data: {
                 csrf_token: $("#mediaDownloadForm input[name=csrf_token]").val(),
                 mediaURL: url,
-                serverURL: currentURL.href,
-                videoQuality: videoQuality,
-                maxVideos: maxVideos,
-                maxVideosSize: maxVideosSize
+                serverURL: currentURL.href
             },
             success: function(response) {
                 // Handle success response here

--- a/cps/templates/modal_dialogs.html
+++ b/cps/templates/modal_dialogs.html
@@ -162,44 +162,6 @@
                 placeholder="{{_('Enter URL')}}">
             </div>
           </div>
-          <!-- Advanced Options Toggle Button -->
-          <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-10">
-              <a href="#" id="advancedOptionsToggle">Show Advanced Options</a>
-            </div>
-          </div>
-          <!-- Advanced Options (Initially Hidden) -->
-          <div id="advancedOptions" style="display: none;">
-            <!-- Video Quality -->
-            <div class="form-group">
-              <label class="col-sm-2 control-label">{{_('Video Quality')}}</label>
-              <div class="col-sm-10">
-                <label class="radio-inline">
-                  <input type="radio" name="videoQuality" value="480">480p
-                </label>
-                <label class="radio-inline">
-                  <input type="radio" name="videoQuality" value="720" checked>720p
-                </label>
-                <label class="radio-inline">
-                  <input type="radio" name="videoQuality" value="1080">1080p
-                </label>
-                <!-- Add more quality options as needed -->
-              </div>
-            </div>
-            <!-- Maximum Number of Videos to Download -->
-            <div class="form-group">
-              <label for="maxVideos" class="col-sm-2 control-label">{{_('Max Videos')}}</label>
-              <div class="col-sm-10">
-                <input type="number" class="form-control" id="maxVideos" name="maxVideos" min="1" max="100">
-              </div>
-            </div>
-            <!-- Maximum Size of All Videos -->
-            <div class="form-group">
-              <label for="maxVideosSize" class="col-sm-2 control-label">{{_('Max Size (GB)')}}</label>
-              <div class="col-sm-10">
-                <input type="number" class="form-control" id="maxVideosSize" name="maxVideosSize" min="1" max="5000">
-              </div>
-            </div>
         </form>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
We use only the URL for now.  