### PR TITLE
Update tasks messages based on the current status

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -328,7 +328,7 @@ def media():
         abort(404)
 
     def request_media_download(media_url, original_url):
-        task_message = N_("learning media from %(media_url)s", media_url=media_url)
+        task_message = N_("fetching %(media_url)s...", media_url=media_url)
         WorkerThread.add(current_user.name, TaskDownload(task_message, media_url, original_url, current_user.name))
         return True
 

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -328,7 +328,7 @@ def media():
         abort(404)
 
     def request_media_download(media_url, original_url):
-        task_message = N_("fetching %(media_url)s...", media_url=media_url)
+        task_message = N_("downloading %(media_url)s...", media_url=media_url)
         WorkerThread.add(current_user.name, TaskDownload(task_message, media_url, original_url, current_user.name))
         return True
 

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -16,6 +16,7 @@ log = logger.create()
 class TaskDownload(CalibreTask):
     def __init__(self, task_message, media_url, original_url, current_user_name):
         super(TaskDownload, self).__init__(task_message)
+        self.message = task_message
         self.media_url = media_url
         self.original_url = original_url
         self.current_user_name = current_user_name
@@ -53,11 +54,16 @@ class TaskDownload(CalibreTask):
                             # 2024-01-10: 99% (a bit arbitrary) is explained here...
                             # https://github.com/iiab/calibre-web/pull/88#issuecomment-1885916421
                             if percentage < 100:
+                                self.message = f"Downloading learning media from {self.media_url}"
                                 self.progress = percentage / 100
                             else:
+                                self.message = f"Processing learning media from {self.media_url}"
                                 self.progress = 0.99
 
                 p.wait()
+                self.progress = 1.0
+                self.message = f"Downloaded learning media from {self.media_url}"
+
 
                 # Database operations
                 requested_files = []

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -56,15 +56,15 @@ class TaskDownload(CalibreTask):
                             # 2024-01-10: 99% (a bit arbitrary) is explained here...
                             # https://github.com/iiab/calibre-web/pull/88#issuecomment-1885916421
                             if percentage < 100:
-                                self.message = f"Downloading learning media from {self.media_url}"
+                                self.message = f"Downloading {self.media_url}..."
                                 self.progress = percentage / 100
                             else:
-                                self.message = f"Processing learning media from {self.media_url}"
+                                self.message = f"Almost done..."
                                 self.progress = 0.99
 
                 p.wait()
                 self.progress = 1.0
-                self.message = f"Downloaded learning media from {self.media_url}"
+                self.message = f"Successfuly downloaded {self.media_url}"
 
 
                 # Database operations


### PR DESCRIPTION
🚀 **Pull Request Overview:**

These changes aim to enhance the download task functionality and messaging:

   - Provide context-specific status updates during the download process.
   - Ensure setting progress to 100% upon completion.
   - Modify the initial message.
   - Reference regex, asserting position of "downloading" at start of a line.

👀  Reviewed as follow:
- [x] Review the updated download task messages for clarity and informativeness.
- [x] Confirm the enhanced handling of download progress updates.
- [x] Check the modified task initialization and ensure compatibility with existing logic.
- [x] Review the refactored subprocess output pattern for clarity and correctness.

🔗 This PR is related to https://github.com/iiab/calibre-web/issues/89

🔄 **Testing Steps:**
1. Start a download task with a valid YouTube URL and observe the messages displayed in Tasks' Task column during the download process.
 2. Confirm that the messages accurately reflect the current state of the download (e.g., "Downloading," "Processing," "Downloaded").
3. Check if the messages are dynamically updated based on the progress and completion status.

📝 **Additional Notes:**
This PR builds upon https://github.com/iiab/calibre-web/pull/88
