### PR TITLE
Revert to original pattern to match the word "downloading"

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -43,7 +43,7 @@ class TaskDownload(CalibreTask):
 
                 # Define the pattern for the subprocess output
                 # Equivalent Regex: https://github.com/iiab/calibre-web/blob/3c3c77f4dbf54ff093c3e3a68ac9b93a522c4070/scripts/lb-wrapper#L26
-                pattern_progress = r"^downloading"
+                pattern_progress = r"downloading"
 
                 while p.poll() is None:
                     line = p.stdout.readline()


### PR DESCRIPTION
We need to match the word "downloading". Adding '^' prevents this and breaks the progress dynamic updates.