### PR TITLE
Redirect to STDOUT instead of STDERR: scripts/lb-wrapper

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -61,7 +61,7 @@ log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
 # 1>&2 redirect back-to-STDERR explained at https://stackoverflow.com/a/15936384
 eval "${XKLB_FULL_CMD}" \
      > >(while read -r line; do log "Info" "$line"; done) \
-     2> >(while read -r line; do log "Warning" "$line" 1>&2; done) &
+     2> >(while read -r line; do log "Warning" "$line"; done) &
 pid=$!
 
 # Wait for background process to complete


### PR DESCRIPTION
I did not use a clean unit test for PR #88, making it pass with the original lb-wrapper from #86. I did not catch that the specific explicit redirection to STDERR introduced in #87 would prevent capturing lines with "downloading..." in them. So I revert back to the working state with this PR changing 

https://github.com/holta/calibre-web/blob/f6c6b738cbf24656ddf867edb2d5de000f6fd6f6/scripts/lb-wrapper#L62C1-L65C7:
```bash
eval "${XKLB_FULL_CMD}" \
     > >(while read -r line; do log "Info" "$line"; done) \
     2> >(while read -r line; do log "Warning" "$line" 1>&2; done) &
pid=$!
```

to

https://github.com/deldesir/calibre-web/blob/09769ef77604bb5998e6a796fea595117173d144/scripts/lb-wrapper#L62C1-L65C7:
```bash
eval "${XKLB_FULL_CMD}" \
     > >(while read -r line; do log "Info" "$line"; done) \
     2> >(while read -r line; do log "Warning" "$line"; done) &
pid=$!
```