### PR TITLE
3 regex's (STDERR, STDIN, Python) to parse yt-dlp download progress, for live display in "Tasks" view

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -48,7 +48,8 @@ class TaskDownload(CalibreTask):
                 while p.poll() is None:
                     line = p.stdout.readline()
                     if line:
-                        #if pattern_progress in line:
+                        #if "downloading" in line:
+                        #if line.startswith("downloading"):
                         if re.search(pattern_progress, line):
                             percentage = int(re.search(r'\d+', line).group())
                             # 2024-01-10: 99% (a bit arbitrary) is explained here...

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -27,7 +27,7 @@ class TaskDownload(CalibreTask):
         """Run the download task"""
         self.worker_thread = worker_thread
         log.info("Starting download task for URL: %s", self.media_url)
-        self.start_time  = self.end_time = datetime.now()
+        self.start_time = self.end_time = datetime.now()
         self.stat = STAT_STARTED
         self.progress = 0
 
@@ -48,7 +48,8 @@ class TaskDownload(CalibreTask):
                 while p.poll() is None:
                     line = p.stdout.readline()
                     if line:
-                        if pattern_progress in line:
+                        #if pattern_progress in line:
+                        if re.search(pattern_progress, line):
                             percentage = int(re.search(r'\d+', line).group())
                             # 2024-01-10: 99% (a bit arbitrary) is explained here...
                             # https://github.com/iiab/calibre-web/pull/88#issuecomment-1885916421

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -23,11 +23,7 @@ mkdir -p ${TMP_DOWNLOADS_DIR}
 log() {
     local level=$1
     local message=$2
-    if [[ $message == downloading* ]]; then
-        echo "$message"
-    else
-        echo "$(date +'%Y-%m-%d %H:%M:%S') - [$level] $message" | tee -a ${LOG_FILE}
-    fi
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - [$level] $message" | tee -a ${LOG_FILE}
 }
 
 if [ $# -eq 0 ]; then
@@ -58,10 +54,18 @@ fi
 log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170
-# 1>&2 redirect back-to-STDERR explained at https://stackoverflow.com/a/15936384
+# 1>&2 redirect back-to-STDERR to avoid nested (repeat) logging, explained at https://stackoverflow.com/a/15936384
 eval "${XKLB_FULL_CMD}" \
-     > >(while read -r line; do log "Info" "$line"; done) \
-     2> >(while read -r line; do log "Warning" "$line" 1>&2; done) &
+     > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
+     2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
+# 2024-10-11: HOW THIS WORKS...
+# 0) xklb sends a flood of yt-dlp status message lines like "downloading  59.8%    2.29MiB/s" to STDERR.
+# 1) Then, "2> >(...)" reroutes (only those raw lines!) to STDIN, instead of logging them (as "Debug" lines).
+# 2) Then, upon receiving them at STDIN, "> >(...)" again prevents (only those raw lines!) from being logged (as "Info" messages).
+# 3) Then, cps/tasks/download.py uses an equivalent Python REGEX to flag (only these raw lines! yes a 3rd time!)
+#    parsing them to send "percentage download progress" info along to the "Tasks" view in the web front-end:
+#    https://github.com/iiab/calibre-web/blob/d594aeba06ab91e684122ca03062564d71f012e5/cps/tasks/download.py#L46
+
 pid=$!
 
 # Wait for background process to complete

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -58,7 +58,7 @@ log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
 eval "${XKLB_FULL_CMD}" \
      > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
      2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
-# 2024-10-11: HOW THIS WORKS...
+# 2024-01-11: HOW THIS WORKS...
 # 0) xklb sends a flood of yt-dlp status message lines like "downloading  59.8%    2.29MiB/s" to STDERR.
 # 1) Then, "2> >(...)" reroutes (only those raw lines!) to STDIN, instead of logging them (as "Debug" lines).
 # 2) Then, upon receiving them at STDIN, "> >(...)" again prevents (only those raw lines!) from being logged (as "Info" messages).


### PR DESCRIPTION
This PR is a proposed alternative to:

- PR #91
- PR #92 

Please see Lines 57-67 of `scripts/lb-wrapper` for an explanation of how this works.  It refines:

- PR #87
- PR #88

My apologies the PR below (89) might need to be rebased, after this PR #93 is hopefully merged soon:

- PR #89

Tangentially related:

- PR iiab/iiab#3697