### PR TITLE
Improve error handling for failed downloads

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -3,7 +3,6 @@ import re
 import requests
 import sqlite3
 from datetime import datetime
-from flask import flash
 from flask_babel import lazy_gettext as N_, gettext as _
 
 from cps.constants import SURVEY_DB_FILE

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -32,7 +32,7 @@ class TaskDownload(CalibreTask):
         self.stat = STAT_STARTED
         self.progress = 0
 
-        lb_executable = self.get_lb_executable()
+        lb_executable = os.getenv("LB_WRAPPER", "lb-wrapper")
 
         if self.media_url:
             subprocess_args = [lb_executable, self.media_url]
@@ -83,37 +83,33 @@ class TaskDownload(CalibreTask):
                     shelf_title = None
                 conn.close()
 
-                if self.original_url:
-                    response = requests.get(self.original_url, params={"requested_files": requested_files, "current_user_name": self.current_user_name, "shelf_title": shelf_title})
-                    if response.status_code == 200:
-                        log.info("Successfully sent the list of requested files to %s", self.original_url)
-                    else:
-                        log.error("Failed to send the list of requested files to %s", self.original_url)
-
-                # Set the progress to 100% and the end time to the current time
-                self.progress = 1
-                self.end_time = datetime.now()
-                self.stat = STAT_FINISH_SUCCESS
-
+                response = requests.get(self.original_url, params={"requested_files": requested_files, "current_user_name": self.current_user_name, "shelf_title": shelf_title})
+                if response.status_code == 200:
+                    log.info("Successfully sent the list of requested files to %s", self.original_url)
+                else:
+                    log.error("Failed to send the list of requested files to %s", self.original_url)
+                    self.progress = 0
+                    self.message = f"{self.media_url} failed to download: {response.status_code} {response.reason}"
+            
             except Exception as e:
                 log.error("An error occurred during the subprocess execution: %s", e)
-                # Handling subprocess failure or errors
-                flash("Failed to complete the download process", category="error")
-                self.stat = STAT_FAIL
+                self.message = f"{self.media_url} failed to download: {e}"
+
+            finally:
+                if p.returncode == 0 and self.progress == 1.0:
+                    self.stat = STAT_FINISH_SUCCESS
+                else:
+                    self.stat = STAT_FAIL
 
         else:
-            log.info("No media URL provided")
-
-    def get_lb_executable(self):
-        lb_executable = os.getenv("LB_WRAPPER", "lb-wrapper")
-        return lb_executable
+            log.info("No media URL provided - skipping download task")
 
     @property
     def name(self):
         return N_("Download")
 
     def __str__(self):
-        return "Download %s" % self.media_url
+        return f"Download task for {self.media_url}"
 
     @property
     def is_cancellable(self):


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This pull request brings following enhancements:

- Improved error handling with detailed error messages, including HTTP status codes and reasons, in case of download failures.
- Set appropriate progress and messages when the download process encounters errors.

These updates aim to provide users with clearer information about download failures.

📋 **Checklist:**
- [x] Tested the changes on Ubuntu 23.10
- [x] Updated relevant documentation: https://github.com/iiab/calibre-web/wiki/Home/_compare/b612eaa9c7c890ccc5dcfe62c6130f0e9392b14b...ed8f1a8402c1ec526c143cf63e193c426be91d9a

🔗 Related Issues: #89 

Some testing steps (thanks @EMG70):
   - Ensure that the script is running in an environment with internet access.
   - Initiate a download task with a valid YouTube or Vimeo URL
   - Confirm that the download progresses successfully.
   - Verify that the completion message reflects the successful download.
   - Check the Task column (in Tasks view)  for success or error messages. Also, check the logs for the message "Successfully downloaded" or an error if any.