### PR TITLE
Revert to upload task

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -455,6 +455,8 @@ def meta():
                     category="error",
                 )
 
+        return True
+
     if request.method == "GET" and "requested_files" in request.args:
         requested_files = request.args.getlist("requested_files")
         current_user_name = request.args.get("current_user_name", None)

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -435,7 +435,7 @@ def meta():
                 link = '<a href="{}">{}</a>'.format(
                     url_for("web.show_book", book_id=book_id), escape(title)
                 )
-                upload_text = N_("File %(file)s uploaded", file=link)
+                upload_text = N_("File %(file)s downloaded", file=link)
                 WorkerThread.add(
                     current_user_name, TaskUpload(upload_text, escape(title))
                 )
@@ -443,14 +443,6 @@ def meta():
 
                 if shelf_title:
                     shelf.add_to_shelf_as_guest(shelf_id, book_id)
-
-                if len(requested_files) < 2:
-                    resp = {
-                        "location": url_for(
-                            "edit-book.show_edit_book", book_id=book_id
-                        )
-                    }
-                    return Response(json.dumps(resp), mimetype="application/json")
 
             except (OperationalError, IntegrityError, StaleDataError) as e:
                 calibre_db.session.rollback()
@@ -462,9 +454,6 @@ def meta():
                     ),
                     category="error",
                 )
-        else:
-            flash("Error: No file found", category="error")
-            return False
 
     if request.method == "GET" and "requested_files" in request.args:
         requested_files = request.args.getlist("requested_files")

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -104,13 +104,7 @@ class TaskDownload(CalibreTask):
                 response = requests.get(self.original_url, params={"requested_files": requested_files, "current_user_name": self.current_user_name, "shelf_title": shelf_title})
                 if response.status_code == 200:
                     log.info("Successfully sent the list of requested files to %s", self.original_url)
-                    files_uploaded = response.json()["files_uploaded"]
-                    if files_uploaded:
-                        self.message = f"Successfuly downloaded {self.media_url}. Uploaded files: "
-                        for i, file in enumerate(files_uploaded):
-                            self.message += f"{i+1}. {file} \n"
-                    else:
-                        self.message = f"Successfuly downloaded {self.media_url}. No files uploaded."
+                    self.message = f"Successfuly downloaded {self.media_url}"
                 else:
                     log.error("Failed to send the list of requested files to %s", self.original_url)
                     self.message = f"{self.media_url} failed to download: {response.status_code} {response.reason}"


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This PR does the following changes:
- Reverts to showing subsequent upload rows for every video dowloaded
- Fixes the bookshelf bug reported in #98 

📋 **Checklist:**
- [x] Tested on Ubuntu 24.04
- [x] Checked for backward compatibility (bookshelf feature)

🔗 Related Issue: #89

📌 **Testing scenarios:**
See Issue #97 

cc @EMG70

