### PR TITLE
Rename and persist xklb database

### DIFF
--- a/cps/constants.py
+++ b/cps/constants.py
@@ -46,7 +46,7 @@ CACHE_DIR           = os.environ.get('CACHE_DIR', DEFAULT_CACHE_DIR)
 
 # 2023-11-15: See scripts/lb-wrapper which uses xklb's 'lb tubeadd ...' to save
 # an initial metadata manifest (prior to downloading videos or media) here:
-SURVEY_DB_FILE      = "/library/downloads/calibre-web/survey.db"
+XKLB_DB_FILE      = "/library/calibre-web/xklb-metadata.db"
 
 if HOME_CONFIG:
     home_dir = os.path.join(os.path.expanduser("~"), ".calibre-web")

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -72,7 +72,7 @@ class TaskDownload(CalibreTask):
                     shelf_title = None
                     try:
                         # Get the requested files from the database
-                        requested_files = list(set([row[0] for row in conn.execute("SELECT path FROM media").fetchall() if not row[0].startswith("http")]))
+                        requested_files = list(set([row[0] for row in conn.execute("SELECT path FROM media WHERE start_time >= ? AND start_time <= ?", (self.start_time, self.end_time)).fetchall() if not row[0].startswith("http")]))
 
                         # Abort if there are no requested files
                         if not requested_files:

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -5,7 +5,7 @@ import sqlite3
 from datetime import datetime
 from flask_babel import lazy_gettext as N_, gettext as _
 
-from cps.constants import SURVEY_DB_FILE
+from cps.constants import XKLB_DB_FILE
 from cps.services.worker import CalibreTask, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_STARTED, STAT_WAITING
 from cps.subproc_wrapper import process_open
 from .. import logger
@@ -68,7 +68,7 @@ class TaskDownload(CalibreTask):
 
                 # Database operations
                 requested_files = []
-                with sqlite3.connect(SURVEY_DB_FILE) as conn:
+                with sqlite3.connect(XKLB_DB_FILE) as conn:
                     shelf_title = None
                     try:
                         # Get the requested files from the database

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -72,7 +72,7 @@ class TaskDownload(CalibreTask):
                     shelf_title = None
                     try:
                         # Get the requested files from the database
-                        requested_files = list(set([row[0] for row in conn.execute("SELECT path FROM media WHERE start_time >= ? AND start_time <= ?", (self.start_time, self.end_time)).fetchall() if not row[0].startswith("http")]))
+                        requested_files = list(set([row[0] for row in conn.execute("SELECT path FROM media").fetchall() if not row[0].startswith("http")]))
 
                         # Abort if there are no requested files
                         if not requested_files:

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -27,7 +27,7 @@ from tempfile import gettempdir
 from flask_babel import gettext as _
 
 from . import logger, comic, isoLanguages
-from .constants import BookMeta, SURVEY_DB_FILE
+from .constants import BookMeta, XKLB_DB_FILE
 from .helper import split_authors
 
 log = logger.create()
@@ -252,8 +252,8 @@ def pdf_preview(tmp_file_path, tmp_dir):
 def video_metadata(tmp_file_path, original_file_name, original_file_extension):
     if ']' in original_file_name:
         video_id = original_file_name.split('[')[1].split(']')[0]
-        if os.path.isfile(SURVEY_DB_FILE):
-            conn = sqlite3.connect(SURVEY_DB_FILE)
+        if os.path.isfile(XKLB_DB_FILE):
+            conn = sqlite3.connect(XKLB_DB_FILE)
             conn.row_factory = sqlite3.Row
             c = conn.cursor()
             c.execute("SELECT * FROM media WHERE extractor_id=?", (video_id,))
@@ -294,7 +294,7 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 return meta
             conn.close()
         else:
-            log.warning('Cannot find survey database, using default metadata')
+            log.warning('Cannot find the xklb database, using default metadata')
     else:
         meta = BookMeta(
             file_path=tmp_file_path,

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -48,11 +48,6 @@ fi
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-# 2024-01-24: Not needed as we don't discard the database anymore
-# if mv ${XKLB_DB_FILE} ${XKLB_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
-#     log "Info" "Old ${XKLB_DB_FILE} moved aside."
-# fi
-
 log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -4,7 +4,7 @@ LOG_FILE="/var/log/xklb.log"
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 VERBOSITY="-vv"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
-SURVEY_DB_FILE="${TMP_DOWNLOADS_DIR}/survey.db"
+XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 URL="$1"
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
@@ -12,8 +12,8 @@ URL="$1"
 # FORMAT_OPTIONS="--format-sort size"
 
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
-XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${SURVEY_DB_FILE} ${URL} ${VERBOSITY} \
-&& ${XKLB_EXECUTABLE} dl ${SURVEY_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
+XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
+&& ${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
 --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 
 
@@ -48,9 +48,10 @@ fi
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-if mv ${SURVEY_DB_FILE} ${SURVEY_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
-    log "Info" "Old ${SURVEY_DB_FILE} moved aside."
-fi
+# 2024-01-24: Not needed as we don't discard the database anymore
+# if mv ${XKLB_DB_FILE} ${XKLB_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
+#     log "Info" "Old ${XKLB_DB_FILE} moved aside."
+# fi
 
 log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
 


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This pull request includes the following enhancements to the download task:

- Renamed survey.db to xklb-metadata.db
- Set the database not to be discarded anymore after each run
- Set the new database location to /library/calibre-web

These changes aim to reuse the database for every download tasks, since we need to retry failed tasks and persist the videos metadata.

📋 **Checklist:**
- [ ] Tested the changes thoroughly.
- [ ] Checked for backward compatibility (bookshelf feature)

🔗 **Related Issue(s)**: 
Issue #104

📌 **Testing scenarios:**
See Issue #97 

cc @EMG70

