### PR TITLE
Refactor lb-wrapper for command separation

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -46,6 +46,7 @@ fi
 # 2024-01-25 Question: "Why separate execution of 'tubeadd' and 'dl' ?"
 # @deldesir Responded: "For listing requested files after tubeadd is done
 # fetching metadata. This will prevent hanging for playlist URLs or short URLs.
+# "...to be able to list videos that are not downloaded yet"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -43,7 +43,7 @@ if ! command -v "${XKLB_EXECUTABLE}"; then
 if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
     xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
 elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then
-    xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
+    xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 else
     log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
     exit 1

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -27,7 +27,7 @@ log() {
 }
 
 if [ $# -ne 2 ]; then
-    log "Error" "Insufficient arguments provided. Please provide a command (tubeadd/dl) and a URL."
+    log "Error" "Two arguments are required. Please provide a command (tubeadd/dl) and a URL."
     exit 1
 fi
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -40,6 +40,9 @@ fi
 #     exit 1
 # fi
 
+if ! command -v "${XKLB_EXECUTABLE}"; then
+    log "Error" "xklb could not be found. Please install xklb and try again."
+
 if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
     xklb_full_cmd="${xklb_full_cmd%%&&*}"
 elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -13,9 +13,6 @@ URL="$2"  # Use $2 for the URL argument
 # FORMAT_OPTIONS="--format-sort size"
 
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
-xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
-&& ${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
---video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
@@ -44,9 +41,9 @@ if ! command -v "${XKLB_EXECUTABLE}"; then
     log "Error" "xklb could not be found. Please install xklb and try again."
 
 if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
-    xklb_full_cmd="${xklb_full_cmd%%&&*}"
+    xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
 elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then
-    xklb_full_cmd="${xklb_full_cmd##*&& }"
+    xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
 else
     log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
     exit 1

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -40,6 +40,8 @@ fi
 
 if ! command -v "${XKLB_EXECUTABLE}"; then
     log "Error" "xklb could not be found. Please install xklb and try again."
+    exit 1
+fi
 
 # 2024-01-25 Question: "Why separate execution of 'tubeadd' and 'dl' ?"
 # @deldesir Responded: "For listing requested files after tubeadd is done

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -5,17 +5,11 @@ XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 VERBOSITY="-vv"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
-URL="$1"
+URL="$2"  # Use $2 for the URL argument
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
 # FORMAT_OPTIONS="--format-sort size"
-
-FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
-XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
-&& ${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
---video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
-
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
@@ -26,10 +20,12 @@ log() {
     echo "$(date +'%Y-%m-%d %H:%M:%S') - [$level] $message" | tee -a ${LOG_FILE}
 }
 
-if [ $# -eq 0 ]; then
-    log "Error" "No arguments provided. Please provide a URL to download."
+if [ $# -lt 2 ]; then
+    log "Error" "Insufficient arguments provided. Please provide a command (tubeadd/dl) and a URL."
     exit 1
 fi
+
+command_type=$1
 
 # URL validation already taken care of by cps/static/js/main.js Lines 167-170
 # which (1) trims outer whitespace, and (2) prepends https:// if URL doesn't
@@ -40,21 +36,26 @@ fi
 #     exit 1
 # fi
 
-if ! command -v "${XKLB_EXECUTABLE}"; then
-    log "Error" "xklb could not be found. Please install xklb and try again."
+if [ "$command_type" == "tubeadd" ]; then
+    XKLB_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
+elif [ "$command_type" == "dl" ]; then
+    FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
+    XKLB_CMD="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
+else
+    log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
     exit 1
 fi
 
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-log "Info" "Running xklb commands: ${XKLB_FULL_CMD}"
+log "Info" "Running xklb command: ${XKLB_CMD}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170
 # 1>&2 redirect back-to-STDERR to avoid nested (repeat) logging, explained at https://stackoverflow.com/a/15936384
-eval "${XKLB_FULL_CMD}" \
-     > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
-     2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
+eval "${XKLB_CMD}" \
+    > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
+    2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
 # 2024-01-11: HOW THIS WORKS...
 # 0) xklb sends a flood of yt-dlp status message lines like "downloading  59.8%    2.29MiB/s" to STDERR.
 # 1) Then, "2> >(...)" reroutes (only those raw lines!) to STDIN, instead of logging them (as "Debug" lines).
@@ -71,7 +72,7 @@ rc=$?
 
 # Check return code (exit status)
 if [ $rc -eq 0 ]; then
-    log "Info" "lb-wrapper's xklb commands (download) completed successfully."
+    log "Info" "lb-wrapper's xklb command (${command_type}) completed successfully."
 else
     log "Error" "Error $rc occurred while running lb-wrapper's xklb commands."
     exit 1

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -52,11 +52,6 @@ fi
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-# 2024-01-24: Not needed as we don't discard the database anymore
-# if mv ${XKLB_DB_FILE} ${XKLB_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
-#     log "Info" "Old ${XKLB_DB_FILE} moved aside."
-# fi
-
 log "Info" "Running xklb command: ${XKLB_FULL_CMD}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -1,22 +1,23 @@
 #!/bin/bash
 
+XKLB_INTERNAL_CMD="$1"
+URL="$2"
+
 LOG_FILE="/var/log/xklb.log"
 XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
-VERBOSITY="-vv"
-TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
-XKLB_INTERNAL_CMD="$1"
-URL="$2"  # Use $2 for the URL argument
+TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+VERBOSITY="-vv"
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
 # FORMAT_OPTIONS="--format-sort size"
-
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
+
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
-# Function to log messages e.g. w/ level "Info", "Warning" or "Error"
+# Function to log messages e.g. w/ level "Info", "Debug" or "Error"
 log() {
     local level=$1
     local message=$2
@@ -40,17 +41,17 @@ fi
 if ! command -v "${XKLB_EXECUTABLE}"; then
     log "Error" "xklb could not be found. Please install xklb and try again."
 
-if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
+# 2024-01-25 Question: "Why separate execution of 'tubeadd' and 'dl' ?"
+# @deldesir Responded: "For listing requested files after tubeadd is done
+# fetching metadata. This will prevent hanging for playlist URLs or short URLs.
+if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
-elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then
+elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
     xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 else
-    log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
+    log "Error" "Invalid xklb command. Please choose 'tubeadd' or 'dl'."
     exit 1
 fi
-
-# 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
-# log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
 log "Info" "Running xklb command: ${xklb_full_cmd}"
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -14,7 +14,6 @@ VERBOSITY="-vv"
 # FORMAT_OPTIONS="--format-sort size"
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
 
-
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
 # Function to log messages e.g. w/ level "Info", "Debug" or "Error"
@@ -61,8 +60,8 @@ log "Info" "Running xklb command: ${xklb_full_cmd}"
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170
 # 1>&2 redirect back-to-STDERR to avoid nested (repeat) logging, explained at https://stackoverflow.com/a/15936384
 eval "${xklb_full_cmd}" \
-    > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
-    2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
+    > >(while read -r line; do if [[ $line == downloading* || $line =~ \[https://.*\]:* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
+    2> >(while read -r line; do if [[ $line == downloading* || $line =~ \[https://.*\]:* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
 # 2024-01-11: HOW THIS WORKS...
 # 0) xklb sends a flood of yt-dlp status message lines like "downloading  59.8%    2.29MiB/s" to STDERR.
 # 1) Then, "2> >(...)" reroutes (only those raw lines!) to STDIN, instead of logging them (as "Debug" lines).

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -13,7 +13,7 @@ URL="$2"  # Use $2 for the URL argument
 # FORMAT_OPTIONS="--format-sort size"
 
 FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
-XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
+xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
 && ${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
 --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 
@@ -41,9 +41,9 @@ fi
 # fi
 
 if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
-    XKLB_FULL_CMD="${XKLB_FULL_CMD%%&&*}"
+    xklb_full_cmd="${xklb_full_cmd%%&&*}"
 elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then
-    XKLB_FULL_CMD="${XKLB_FULL_CMD##*&& }"
+    xklb_full_cmd="${xklb_full_cmd##*&& }"
 else
     log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
     exit 1
@@ -52,11 +52,11 @@ fi
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-log "Info" "Running xklb command: ${XKLB_FULL_CMD}"
+log "Info" "Running xklb command: ${xklb_full_cmd}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170
 # 1>&2 redirect back-to-STDERR to avoid nested (repeat) logging, explained at https://stackoverflow.com/a/15936384
-eval "${XKLB_FULL_CMD}" \
+eval "${xklb_full_cmd}" \
     > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
     2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
 # 2024-01-11: HOW THIS WORKS...

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -20,7 +20,7 @@ log() {
     echo "$(date +'%Y-%m-%d %H:%M:%S') - [$level] $message" | tee -a ${LOG_FILE}
 }
 
-if [ $# -lt 2 ]; then
+if [ $# -ne 2 ]; then
     log "Error" "Insufficient arguments provided. Please provide a command (tubeadd/dl) and a URL."
     exit 1
 fi

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-XKLB_INTERNAL_CMD="$1"
+XKLB_INTERNAL_CMD="$1"    # e.g. "tubeadd" or "dl"
 URL="$2"
 
 LOG_FILE="/var/log/xklb.log"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -5,11 +5,17 @@ XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 VERBOSITY="-vv"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
+XKLB_INTERNAL_CMD=$1
 URL="$2"  # Use $2 for the URL argument
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
 # FORMAT_OPTIONS="--format-sort size"
+
+FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
+XKLB_FULL_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY} \
+&& ${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} \
+--video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 
 mkdir -p ${TMP_DOWNLOADS_DIR}
 
@@ -25,8 +31,6 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-command_type=$1
-
 # URL validation already taken care of by cps/static/js/main.js Lines 167-170
 # which (1) trims outer whitespace, and (2) prepends https:// if URL doesn't
 # already begin with http:// or https://              (Test below means well,
@@ -36,11 +40,10 @@ command_type=$1
 #     exit 1
 # fi
 
-if [ "$command_type" == "tubeadd" ]; then
-    XKLB_CMD="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
-elif [ "$command_type" == "dl" ]; then
-    FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
-    XKLB_CMD="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
+if [ "$XKLB_INTERNAL_CMD" == "tubeadd" ]; then
+    XKLB_FULL_CMD="${XKLB_FULL_CMD%%&&*}"
+elif [ "$XKLB_INTERNAL_CMD" == "dl" ]; then
+    XKLB_FULL_CMD="${XKLB_FULL_CMD##*&& }"
 else
     log "Error" "Invalid command. Please choose 'tubeadd' or 'dl'."
     exit 1
@@ -49,11 +52,16 @@ fi
 # 2024-01-21: Not needed as XKLB reports its own version# to /var/log/xklb.log
 # log "Info" "xklb version: $(${XKLB_EXECUTABLE} --version)"
 
-log "Info" "Running xklb command: ${XKLB_CMD}"
+# 2024-01-24: Not needed as we don't discard the database anymore
+# if mv ${XKLB_DB_FILE} ${XKLB_DB_FILE}.$(date +%F_%T_%Z) 2> /dev/null; then
+#     log "Info" "Old ${XKLB_DB_FILE} moved aside."
+# fi
+
+log "Info" "Running xklb command: ${XKLB_FULL_CMD}"
 
 # >(...) "process substitution" explained at https://unix.stackexchange.com/a/324170
 # 1>&2 redirect back-to-STDERR to avoid nested (repeat) logging, explained at https://stackoverflow.com/a/15936384
-eval "${XKLB_CMD}" \
+eval "${XKLB_FULL_CMD}" \
     > >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Info" "$line"; fi; done) \
     2> >(while read -r line; do if [[ $line == downloading* ]]; then echo "$line"; else log "Debug" "$line" 1>&2; fi; done) &
 # 2024-01-11: HOW THIS WORKS...
@@ -72,7 +80,7 @@ rc=$?
 
 # Check return code (exit status)
 if [ $rc -eq 0 ]; then
-    log "Info" "lb-wrapper's xklb command (${command_type}) completed successfully."
+    log "Info" "lb-wrapper's xklb command (${XKLB_INTERNAL_CMD}) completed successfully."
 else
     log "Error" "Error $rc occurred while running lb-wrapper's xklb commands."
     exit 1

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -5,7 +5,7 @@ XKLB_EXECUTABLE="${XKLB_EXECUTABLE:-lb}"
 VERBOSITY="-vv"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
-XKLB_INTERNAL_CMD=$1
+XKLB_INTERNAL_CMD="$1"
 URL="$2"  # Use $2 for the URL argument
 
 # Or download largest possible HD-style / UltraHD videos, to try to force


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This pull request modified lb-wrapper to allow separate execution of 'tubeadd' and 'dl' commands. The script now takes a command type ('tubeadd' or 'dl') as the first argument, allowing users to choose which xklb command to run. Each command is executed independently with its own set of options. 

This aims to facilitate the listing of requested files once `lb tubeadd` is done fetching metadata.

📋 **Checklist:**
- [x] Tested the changes thoroughly.

🔗 **Related Issue(s)**: 
Issue #104

📌 **Testing scenarios:**
See Issue #97 

cc @EMG70

PS _This PR builds upon #109_

