### PR TITLE
Update the video path upon successful download

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -441,6 +441,8 @@ def meta():
             if shelf_id is not None:
                 shelf.add_to_shelf_as_guest(shelf_id, book_id)
 
+            book_path = db_book.path
+
         except (OperationalError, IntegrityError, StaleDataError) as e:
             calibre_db.session.rollback()
             log.error_or_exception("Database error: {}".format(e))
@@ -452,7 +454,8 @@ def meta():
                 category="error",
             )
 
-        resp = {"file_downloaded": link, "shelf_id": shelf_id}
+        new_book_path = os.path.join(config.config_calibre_dir, book_path)
+        resp = {"file_downloaded": link, "shelf_id": shelf_id, "new_book_path": new_book_path}
         return resp
 
     if request.method == "GET" and "requested_file" in request.args:


### PR DESCRIPTION
🚀 **Pull Request Overview:**

A successful download means the video file is moved to /library/calibre-web/. This PR update the xklb-metadata.db with the new path. This prevents total failures on redownloads.

📋 **Checklist:**
- [x] Tested the changes thoroughly.

:bug:  **Related issue**: #117 

📌 **Testing scenarios:**
See Issue #97 

cc @EMG70

