### PR TITLE
Ignore failed URLs in new downloads

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -53,7 +53,7 @@ class TaskMetadataExtract(CalibreTask):
                 with sqlite3.connect(XKLB_DB_FILE) as conn:
                     try:
                         # Get the urls from the database
-                        requested_urls = list(set([row[0] for row in conn.execute("SELECT path FROM media").fetchall() if row[0].startswith("http")]))
+                        requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE error IS NULL").fetchall() if row[0].startswith("http")]
 
                         # Abort if there are no urls
                         if not requested_urls:


### PR DESCRIPTION
🚀 **Pull Request Overview:**

With this PR, failed URLs will not carry on new downloads. No need to delete the database prior testing anymore (we used to do this to have a clean testing environment).

Only the URL submitted (or the ones in case of a Playlist) will be processed.

📋 **Checklist:**
- [x] Tested the changes thoroughly.

:bug:  **Related issue(s)**: #114, #120

📌 **Testing scenarios:**
- Submit a membership-only or a live URL
- Observe the NoneType Error
- Submit a valid URL
- Observe the successful download without an additional attempt to download the previous failed URL

cc @EMG70

