### PR TITLE
Column error does not exist until lb dl is run

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -53,7 +53,11 @@ class TaskMetadataExtract(CalibreTask):
                 with sqlite3.connect(XKLB_DB_FILE) as conn:
                     try:
                         # Get the urls from the database
-                        requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE error IS NULL").fetchall() if row[0].startswith("http")]
+                        error_exists = conn.execute("SELECT error FROM media WHERE error IS NOT NULL").fetchone()
+                        if error_exists:
+                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE error IS NULL").fetchall() if row[0].startswith("http")]
+                        else:
+                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media").fetchall() if row[0].startswith("http")]                       
 
                         # Abort if there are no urls
                         if not requested_urls:


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This PR checks whether column error exists or not. This make new valid downloads fail safe when an invalid URL was submitted in a previous session. 

📋 **Checklist:**
- [x] Tested the changes thoroughly.

:bug:  **Related issue(s)**: #114, #120, #121

📌 **Testing scenarios:**
- Submit a membership-only or a live URL
- Observe the NoneType Error
- Submit a valid URL
- Observe the successful download without an additional attempt to download the previous failed URL

cc @EMG70

