### PR TITLE
Ensure fail-safe downloads when an invalid URL was submitted in a previous session 

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -52,12 +52,12 @@ class TaskMetadataExtract(CalibreTask):
                 requested_urls = []
                 with sqlite3.connect(XKLB_DB_FILE) as conn:
                     try:
-                        # Get the urls from the database
-                        error_exists = conn.execute("SELECT error FROM media WHERE error IS NOT NULL").fetchone()
-                        if error_exists:
-                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE error IS NULL").fetchall() if row[0].startswith("http")]
+                        cursor = conn.execute("PRAGMA table_info(media)")
+                        columns = [column[1] for column in cursor.fetchall()]
+                        if "error" in columns:
+                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE error IS NULL AND path LIKE 'http%'").fetchall()]
                         else:
-                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media").fetchall() if row[0].startswith("http")]                       
+                            requested_urls = [row[0] for row in conn.execute("SELECT path FROM media WHERE path LIKE 'http%'").fetchall()]
 
                         # Abort if there are no urls
                         if not requested_urls:


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This PR checks whether column error exists or not using the `PRAGMA table_info(media)` statement. This statement retrieves information about the columns in the "media" table. Column "error won't exist if xklb-metadata.db is created by the current run/session. In this case, the first error will be a TypeError and reported as such. If xklb-metadata.db exists prior the run/session, meaningful errors are retrieved from error column instead. 

NB This PR is a rework of #122, ensuring new valid downloads will not fail when an invalid URL was submitted in a previous session. 

📋 **Checklist:**
- [x] Tested the changes thoroughly.

:bug:  **Related issue(s)**: #114, #120

📌 **Testing scenarios:**
- Submit a membership-only or a live URL
- Observe the NoneType Error
- Submit a valid URL
- Observe the successful download without an additional attempt to download the previous failed URL

cc @EMG70

