### PR TITLE
Download a single video instead of all videos in a playlist

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -49,7 +49,7 @@ fi
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="${XKLB_EXECUTABLE} tubeadd ${XKLB_DB_FILE} ${URL} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
+    xklb_full_cmd="${XKLB_EXECUTABLE} dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video --search ${URL} ${FORMAT_OPTIONS} --write-thumbnail ${VERBOSITY}"
 else
     log "Error" "Invalid xklb command. Please choose 'tubeadd' or 'dl'."
     exit 1


### PR DESCRIPTION
🚀 **Pull Request Overview:**

This PR ensures a single video is downloaded using its relevant url from all those added to the database by `lb tubeadd`

📋 **Checklist:**
- [x] Tested the changes on Ubuntu 24.04

:bug:  **Related issue(s)**: #114, #120

📌 **Testing scenarios:**
- Submit a valid playlist URL
- Observe the sequential progress polling for each download
- Observe accurate runtime (not 0s) in Runtime column
- Observe the successful downloads of all videos

![Screenshot_20240209-080523](https://github.com/iiab/calibre-web/assets/16546989/538afd3a-85fb-4042-b90f-ecca85d2ff03)


cc @EMG70

