### PR TITLE
Fix "405 METHOD NOT ALLOWED" by (1) Removing query parameters (2) Changing /media to /meta

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -20,6 +20,7 @@ class TaskMetadataExtract(CalibreTask):
         self.message = task_message
         self.media_url = media_url
         self.media_url_link = f'<a href="{media_url}" target="_blank">{media_url}</a>'
+        # (?=...) is a "lookahead assertion" https://docs.python.org/3/library/re.html#regular-expression-syntax
         self.original_url = re.sub(r"(/media)(?=\?|$)", r"/meta", original_url)
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -19,7 +19,7 @@ class TaskMetadataExtract(CalibreTask):
         self.message = task_message
         self.media_url = media_url
         self.media_url_link = f'<a href="{media_url}" target="_blank">{media_url}</a>'
-        self.original_url = original_url.split("?")[0].replace("media", "meta")
+        self.original_url = original_url.split("?")[0].replace("/media", "/meta")
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_WAITING

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -21,7 +21,7 @@ class TaskMetadataExtract(CalibreTask):
         self.media_url = media_url
         self.media_url_link = f'<a href="{media_url}" target="_blank">{media_url}</a>'
         # (?=...) is a "lookahead assertion" https://docs.python.org/3/library/re.html#regular-expression-syntax
-        self.original_url = re.sub(r"(/media)(?=\?|$)", r"/meta", original_url)
+        self.original_url = re.sub(r"/media(?=\?|$)", r"/meta", original_url)
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_WAITING

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -19,7 +19,7 @@ class TaskMetadataExtract(CalibreTask):
         self.message = task_message
         self.media_url = media_url
         self.media_url_link = f'<a href="{media_url}" target="_blank">{media_url}</a>'
-        self.original_url = original_url
+        self.original_url = original_url.split("?")[0].replace("media", "meta")
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_WAITING

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -1,4 +1,5 @@
 import os
+import re
 import requests
 import sqlite3
 from datetime import datetime
@@ -19,7 +20,7 @@ class TaskMetadataExtract(CalibreTask):
         self.message = task_message
         self.media_url = media_url
         self.media_url_link = f'<a href="{media_url}" target="_blank">{media_url}</a>'
-        self.original_url = original_url.split("?")[0].replace("/media", "/meta")
+        self.original_url = re.sub(r"(/media)(?=\?|$)", r"/meta", original_url)
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_WAITING


### PR DESCRIPTION
🚀 **Pull Request Overview:**
Fixes 405 METHOD NOT ALLOWED by cleaning up the endpoint so no query parameters are included and also ensure its correctness (/meta) when the download button is clicked outside of the tasks view.

📋 **Checklist:**
- [x] Tested the change on 10.8.0.22 (Ubuntu 24.04)

Related issue: #106
