### PR TITLE
Increase task cleanup trigger to 101

### DIFF
--- a/cps/services/worker.py
+++ b/cps/services/worker.py
@@ -41,7 +41,7 @@ STAT_ENDED = 4
 STAT_CANCELLED = 5
 
 # Only retain this many tasks in dequeued list
-TASK_CLEANUP_TRIGGER = 20
+TASK_CLEANUP_TRIGGER = 101
 
 QueuedTask = namedtuple('QueuedTask', 'num, user, added, task, hidden')
 


### PR DESCRIPTION
🚀 **Pull Request Overview:**

Prevent older tasks from being hidden as new ones are processed when 100 videos or less are requested.
101 = 1st task (metadata fetch) + 100 next tasks (download)

📋 **Checklist:**
- [x] Tested the change on 10.8.0.22 (Ubuntu 24.04)

Related issue: #132 

First task is displayed in this previous affected 35 videos playlist:
![list](https://github.com/iiab/calibre-web/assets/16546989/3f5db741-51a4-4ffb-9f85-6c2fdd275e39)


