### PR TITLE
Enable subsequent [re]downloads of playlists

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -171,7 +171,7 @@ class TaskMetadataExtract(CalibreTask):
                 self._update_metadata(requested_urls)
                 self._calculate_views_per_day(requested_urls, conn)
                 requested_urls = self._sort_and_limit_requested_urls(requested_urls)
-                conn.execute("UPDATE playlists SET path = ? WHERE extractor_playlist_id = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", self.media_url.split("list=")[-1]))
+                conn.execute("UPDATE playlists SET path = ? WHERE path = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", self.media_url))
 
             else:
                 try:

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -171,6 +171,8 @@ class TaskMetadataExtract(CalibreTask):
                 self._update_metadata(requested_urls)
                 self._calculate_views_per_day(requested_urls, conn)
                 requested_urls = self._sort_and_limit_requested_urls(requested_urls)
+                conn.execute("UPDATE playlists SET path = ? WHERE extractor_playlist_id = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", self.media_url.split("list=")[-1]))
+
             else:
                 try:
                     extractor_id = conn.execute("SELECT extractor_id FROM media WHERE ? LIKE '%' || extractor_id || '%'", (self.media_url,)).fetchone()[0]


### PR DESCRIPTION
Fixes #150. This PR adds a timestamp to playlists' paths after they are downloaded.

[ 2024-05-30 SUMMARY: xklb generally does not support subsequent redownloading of playlists, so let's try this workaround! ]