### PR TITLE
Remove residual fragments from failed video

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -78,8 +78,12 @@ class TaskDownload(CalibreTask):
                     else:
                         fragment_stuck_time += 0.1
                         if fragment_stuck_time >= fragment_stuck_timeout:
-                            log.error("Download appears to be stuck.")
-                            self.record_error_in_database("Download appears to be stuck.")
+                            with sqlite3.connect(XKLB_DB_FILE) as conn:
+                                requested_file = conn.execute("SELECT path FROM media WHERE webpath = ? AND path NOT LIKE 'http%'", (self.media_url,)).fetchone()[0]
+                                if requested_file:
+                                    os.remove(requested_file)
+                                    conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
+                                    conn.commit()
                             raise ValueError("Download appears to be stuck.")
 
                     sleep(0.1)


### PR DESCRIPTION
When a video failed due to unavailable fragments, a subsequent redownload will try to use the residual fragments from the previous download. This is because the download process did not go through to the point to have a video file and a thumbnail downloaded. Since the media.path did not synchronize with the actual calibre-web book path and no timestamp wasn't applied to the media.webpath, these residual fragments affects subsequent redownloads, thus their removal.