### PR TITLE
Fix missing cover

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -267,13 +267,10 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 pubdate = row['time_uploaded']
                 pubdate = datetime.datetime.fromtimestamp(pubdate).strftime('%Y-%m-%d %H:%M:%S')
                 # find cover file
-                if os.path.isdir(os.path.dirname(row['path'])):
-                    for file in os.listdir(os.path.dirname(row['path'])):
-                        if file.lower().endswith(('.webp', '.jpg', '.png', '.gif')) and os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
-                            cover_file_path = os.path.join(os.path.dirname(row['path']), file)
-                            break
+                if os.path.isfile(os.path.join(os.path.dirname(os.path.dirname(row['path'])), f'{video_id}.webp')):
+                    cover_file_path = os.path.join(os.path.dirname(os.path.dirname(row['path'])), f'{video_id}.webp')
                 else:
-                    log.warning('Cannot find .webp file, using default cover')
+                    log.warning('Cannot find thumbnail file, using default cover')
                     cover_file_path = os.path.splitext(tmp_file_path)[0] + '.cover.jpg'
                 c.execute("SELECT * FROM captions WHERE media_id=?", (row['id'],))
                 row = c.fetchone()

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -267,9 +267,8 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                 pubdate = row['time_uploaded']
                 pubdate = datetime.datetime.fromtimestamp(pubdate).strftime('%Y-%m-%d %H:%M:%S')
                 # find cover file
-                if os.path.isfile(os.path.join(os.path.dirname(os.path.dirname(row['path'])), f'{video_id}.webp')):
-                    cover_file_path = os.path.join(os.path.dirname(os.path.dirname(row['path'])), f'{video_id}.webp')
-                else:
+                cover_file_path = os.path.join(os.path.dirname(os.path.dirname(row['path'])), f'{video_id}.webp')
+                if not os.path.isfile(cover_file_path):
                     log.warning('Cannot find thumbnail file, using default cover')
                     cover_file_path = os.path.splitext(tmp_file_path)[0] + '.cover.jpg'
                 c.execute("SELECT * FROM captions WHERE media_id=?", (row['id'],))


### PR DESCRIPTION
The thumbnails are no longer downloaded in their relevant video directories. They are actually placed outside one level up. This PR adjusts the uploading mechanism to find and process them. 

Tested on Ubuntu 24.10.

![Screenshot 2024-05-27 153402](https://github.com/iiab/calibre-web/assets/16546989/a5d8eac0-4fff-4b2e-b4f9-a9d1f3632b89)
