### PR TITLE
Increase "fragment stuck" timeout to 30s

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -51,7 +51,7 @@ class TaskDownload(CalibreTask):
 
                 complete_progress_cycle = 0
 
-                fragment_stuck_timeout = 10  # seconds
+                fragment_stuck_timeout = 30  # seconds
                 fragment_stuck_time = 0
 
                 while p.poll() is None:


### PR DESCRIPTION
Fixes many videos failures due to progress polling hanging for some amount of time.

Tested on Ubuntu 24.10 (t4) but needs further testing from @EMG70 and others.

Related to #168 