### PR TITLE
Enhance timeout check to avoid false positives during processing

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -6,9 +6,9 @@ import sqlite3
 from datetime import datetime
 from flask_babel import lazy_gettext as N_, gettext as _
 
-from calibreweb.cps.constants import XKLB_DB_FILE
-from calibreweb.cps.services.worker import CalibreTask, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_STARTED, STAT_WAITING
-from calibreweb.cps.subproc_wrapper import process_open
+from cps.constants import XKLB_DB_FILE
+from cps.services.worker import CalibreTask, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_STARTED, STAT_WAITING
+from cps.subproc_wrapper import process_open
 from .. import logger
 from time import sleep
 

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -6,9 +6,9 @@ import sqlite3
 from datetime import datetime
 from flask_babel import lazy_gettext as N_, gettext as _
 
-from ..constants import XKLB_DB_FILE
-from ..services.worker import CalibreTask, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_STARTED, STAT_WAITING
-from ..subproc_wrapper import process_open
+from calibreweb.cps.constants import XKLB_DB_FILE
+from calibreweb.cps.services.worker import CalibreTask, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_STARTED, STAT_WAITING
+from calibreweb.cps.subproc_wrapper import process_open
 from .. import logger
 from time import sleep
 

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -81,11 +81,9 @@ class TaskDownload(CalibreTask):
                     else:
                         elapsed_time = (datetime.now() - last_progress_time).total_seconds()
                         if elapsed_time >= fragment_stuck_timeout:
-                            log.error("Download appears to be stuck at unavailable fragment.")
                             self.record_error_in_database("Download appears to be stuck at unavailable fragment.")
                             raise ValueError("Download appears to be stuck at unavailable fragment.")
                         if self.progress == 0.99 and elapsed_time >= progress_stuck_timeout:
-                            log.error("Download appears to be stuck at 100%.")
                             self.record_error_in_database("Download appears to be stuck at 100%.")
                             raise ValueError("Download appears to be stuck at 100%.")
 

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -55,6 +55,7 @@ class TaskDownload(CalibreTask):
                 fragment_stuck_timeout = 30  # seconds
 
                 while p.poll() is None:
+                    self.end_time = datetime.now()
                     # Check if there's data available to read
                     rlist, _, _ = select.select([p.stdout], [], [], 0.1)
                     if rlist:
@@ -69,7 +70,6 @@ class TaskDownload(CalibreTask):
                                 percentage = int(re.search(r'\d+', line).group())
                                 if percentage < 100:
                                     self.message = f"Downloading {self.media_url_link}..."
-                                    self.end_time = datetime.now()
                                     self.progress = min(0.99, (complete_progress_cycle + (percentage / 100)) / 4)
                                 if percentage == 100:
                                     complete_progress_cycle += 1
@@ -124,12 +124,11 @@ class TaskDownload(CalibreTask):
                 self.record_error_in_database(str(e))
 
             finally:
+                self.end_time = datetime.now()
                 if p.returncode == 0 or self.progress == 1.0:
-                    self.end_time = datetime.now()
                     self.stat = STAT_FINISH_SUCCESS
                     log.info("Download task for %s completed successfully", self.media_url)
                 else:
-                    self.end_time = datetime.now()
                     self.stat = STAT_FAIL
 
         else:


### PR DESCRIPTION
This PR fixes the very frustrating timeout issue which led to premature moves of video files. Now the download progress polling goes on par with xklb's `lb dl` execution. Upon [reaching] the timeout limit, the user will only be flashed a status message about the [abnormal] delay. The task will fail due to unavailable fragment only when xklb fails.

Tested rigorously and proudly on Ubuntu 24.10 (t4). Fix applied successfully on LRN2.

![image](https://github.com/iiab/calibre-web/assets/16546989/0bae15b5-6da6-4a77-bee7-0cc4836ef5a7)
