### PR TITLE
Simplify playlists identification [for non-YouTube playlists e.g. Vimeo showcases, Bilibili.tv / Bilibili.com anthologies, etc]

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -21,7 +21,7 @@ class TaskMetadataExtract(CalibreTask):
         self.media_url = self._format_media_url(media_url)
         self.media_url_link = f'<a href="{self.media_url}" target="_blank">{self.media_url}</a>'
         self.original_url = self._format_original_url(original_url)
-        self.type_of_url = None
+        self.is_playlist = None
         self.current_user_name = current_user_name
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_WAITING
@@ -43,11 +43,8 @@ class TaskMetadataExtract(CalibreTask):
             self._get_type_of_url(self.media_url)
             while p.poll() is None:
                 line = p.stdout.readline()
-                if "Importing playlist-less media" in line:
-                    self.type_of_url = "video"
-                    break
-                elif "[download] Downloading playlist:" in line:
-                    self.type_of_url = "playlist"
+                if "[download] Downloading playlist:" in line:
+                    self.is_playlist = True
                     self.shelf_title = line.split("Downloading playlist: ")[1].strip()
                     log.info("***Playlist title***: %s", self.shelf_title)
                     break
@@ -152,7 +149,7 @@ class TaskMetadataExtract(CalibreTask):
             if not requested_urls:
                 return
 
-            if self.type_of_url != "video":
+            if self.is_playlist:
                 self._send_shelf_title()
                 self._update_metadata(requested_urls)
                 self._calculate_views_per_day(requested_urls, conn)

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -40,7 +40,6 @@ class TaskMetadataExtract(CalibreTask):
     def _execute_subprocess(self, subprocess_args):
         try:
             p = process_open(subprocess_args, newlines=True)
-            self._get_type_of_url(self.media_url)
             while p.poll() is None:
                 line = p.stdout.readline()
                 if "[download] Downloading playlist:" in line:

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -45,7 +45,6 @@ class TaskMetadataExtract(CalibreTask):
                 if "[download] Downloading playlist:" in line:
                     self.is_playlist = True
                     self.shelf_title = line.split("Downloading playlist: ")[1].strip()
-                    log.info("***Playlist title***: %s", self.shelf_title)
                     break
             p.wait()
             self.message = self.media_url_link + "..."

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -38,10 +38,11 @@ class TaskMetadataExtract(CalibreTask):
         return re.sub(r"/media(?=\?|$)", r"/meta", original_url)
 
     def _get_type_of_url(self, media_url):
-        if "list=" in media_url:
-            return "playlist"
-        elif "@" in media_url:
-            return "channel"
+        if "youtube.com" or "youtu.be" in media_url:
+            if "list=" in media_url:
+                return "playlist"
+            elif "@" in media_url:
+                return "channel"
         else:
             return "video"
 


### PR DESCRIPTION
The current playlist and channel identification works only for YouTube. This PR simplifies the check before metadata is fetched.