### PR TITLE
Read error from xklb-metadata.db [leveraging yt-dlp STDERR]

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -138,7 +138,6 @@ class TaskDownload(CalibreTask):
         with sqlite3.connect(XKLB_DB_FILE) as conn:
             error = conn.execute("SELECT error FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
         conn.close()
-        conn.execute("UPDATE media SET webpath = ? WHERE webpath = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", self.media_url))
         return error
 
     @property

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -138,6 +138,7 @@ class TaskDownload(CalibreTask):
         with sqlite3.connect(XKLB_DB_FILE) as conn:
             error = conn.execute("SELECT error FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
         conn.close()
+        conn.execute("UPDATE media SET webpath = ? WHERE webpath = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", self.media_url))
         return error
 
     @property


### PR DESCRIPTION
Instead of reporting the exception as a status message, this PR reads the error from xklb db. This enhances debugging. Exception will still be logged because they're useful to understand errors from calibre-web's context. Reading the error from the database helps understand errors from xklb's context leveraging yt-dlp STDERR. 