### PR TITLE
Set outtmpl externally [to avoid missing thumbnails; NOTE: archival-quality book & video titles are preserved in 2 SQLite db's]

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -274,7 +274,7 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
                         # FYI yt_dlp uses YouTube and Vimeo "extractors" -- among ~1810 websites it can scrape:
                         # https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md
                         # https://github.com/yt-dlp/yt-dlp/tree/master/yt_dlp/extractor
-                        if file.lower().endswith(('.webp', '.jpg', '.png', '.gif')) and os.path.splitext(file)[0] == video_id:
+                        if file.lower().endswith(('.webp', '.jpg', '.png', '.gif')) and os.path.splitext(file)[0] == os.path.splitext(os.path.basename(row['path']))[0]:
                             cover_file_path = os.path.join(os.path.dirname(row['path']), file)
                             break
                 else:

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -6,6 +6,9 @@ URL_OR_SEARCH_TERM="$2"
 LOG_FILE="/var/log/xklb.log"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+# outtmpl explanation:
+# https://github.com/yt-dlp/yt-dlp#output-template
+# https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L508-L523
 OUTTMPL="'${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s'"
 VERBOSITY="-vv"
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -8,6 +8,7 @@ XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 # outtmpl explanation:
 # https://github.com/yt-dlp/yt-dlp#output-template
+# https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L385-L388
 # https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L508-L523
 OUTTMPL="'${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s'"
 VERBOSITY="-vv"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -6,7 +6,7 @@ URL_OR_SEARCH_TERM="$2"
 LOG_FILE="/var/log/xklb.log"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
-OUTTMPL="%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s"
+OUTTMPL="'${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s'"
 VERBOSITY="-vv"
 
 PATTERNS=(
@@ -72,7 +72,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd ${XKLB_DB_FILE} ${URL_OR_SEARCH_TERM} --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video --search ${URL_OR_SEARCH_TERM} ${FORMAT_OPTIONS} --write-thumbnail --subs -o ${OUTTMPL} ${VERBOSITY}"
+    xklb_full_cmd="lb dl ${XKLB_DB_FILE} --video --search ${URL_OR_SEARCH_TERM} ${FORMAT_OPTIONS} --write-thumbnail --subs -o ${OUTTMPL} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search ${XKLB_DB_FILE} ${URL_OR_SEARCH_TERM}"
 else

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -10,6 +10,11 @@ TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 # https://github.com/yt-dlp/yt-dlp#output-template
 # https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L385-L388
 # https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L508-L523
+# /library/downloads/calibre-web/                                                                         (TMP_DOWNLOADS_DIR)
+# └── Youtube                                                                                             (extractor)
+#     └── TED-Ed                                                                                          (uploader_id)
+#         ├── How does an air conditioner actually work？ - Anna Rothschild_224.59k_[6sSDXurPX-s].mp4     ([video file] title + view_count + video_id + extension)
+#         └── How does an air conditioner actually work？ - Anna Rothschild_224.59k_[6sSDXurPX-s].webp    ([thumbnail] title + view_count + video_id + extension)
 OUTTMPL="'${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s'"
 VERBOSITY="-vv"
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -6,6 +6,7 @@ URL_OR_SEARCH_TERM="$2"
 LOG_FILE="/var/log/xklb.log"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
+OUTTMPL="%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s"
 VERBOSITY="-vv"
 
 PATTERNS=(
@@ -71,7 +72,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd ${XKLB_DB_FILE} ${URL_OR_SEARCH_TERM} --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video --search ${URL_OR_SEARCH_TERM} ${FORMAT_OPTIONS} --write-thumbnail --subs ${VERBOSITY}"
+    xklb_full_cmd="lb dl ${XKLB_DB_FILE} --prefix ${TMP_DOWNLOADS_DIR} --video --search ${URL_OR_SEARCH_TERM} ${FORMAT_OPTIONS} --write-thumbnail --subs -o ${OUTTMPL} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search ${XKLB_DB_FILE} ${URL_OR_SEARCH_TERM}"
 else


### PR DESCRIPTION
Set "out directory" template externally so video file + thumbnail can be retrieved. This should fix the missing thumbnail issue explained in https://github.com/iiab/calibre-web/issues/171#issuecomment-2156319102.

Tested on Ubuntu 24.04
![image](https://github.com/iiab/calibre-web/assets/16546989/a932bbf5-ac64-4e24-90a6-4cc088b20d9b)

![image](https://github.com/iiab/calibre-web/assets/16546989/f6aa4b1c-dab8-44a6-b255-f0f41fbbeefd)