### PR TITLE
Display shelf title [name & link in "Tasks" view, when downloading a playlist or channel to IIAB]

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -134,6 +134,9 @@ class TaskMetadataExtract(CalibreTask):
             self.message = self.media_url_link + f"<br><br>" \
                            f"Number of Videos: {index + 1}/{num_requested_urls}<br>" \
                            f"Total Duration: {datetime.utcfromtimestamp(total_duration).strftime('%H:%M:%S')}"
+            if self.shelf_title:
+                shelf_url = re.sub(r"/meta(?=\?|$)", r"/shelf", self.original_url) + f"/{self.shelf_id}"
+                self.message += f"<br><br>Shelf Title: <a href='{shelf_url}' target='_blank'>{self.shelf_title}</a>"
             if self.unavailable:
                 self.message += f"<br><br>Unavailable Video(s):<br>{'<br>'.join(f'<a href="{url}" target="_blank">{url}</a>' for url in self.unavailable)}"
 


### PR DESCRIPTION
Upon each "metadata fetch" when a playlist or channel is submitted, the user will be able to click on the shelf title.

![image](https://github.com/iiab/calibre-web/assets/16546989/5de8d73f-59d9-4d0f-b15a-7b7b5e56e599)

Tested on ubuntu 24.04 (LRN2)