### PR TITLE
Clear input field when download modal is shown

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -258,6 +258,11 @@ $(document).ready(function() {
         }
     });
 
+    // Clear the input field when the modal is shown
+    $("#mediaDownloadModal").on('shown.bs.modal', function() {
+        $("#mediaURL").val("");
+    });
+
     /*
     // Function to validate URL
     function isValidURL(url) {


### PR DESCRIPTION
With this change, each time the download modal is displayed, the URL input field will be cleared, ensuring that users always see an empty input field when starting a new download.

Fixes #181 
cc @avni

Tested on Ubuntu 24.04 (LRN2)