### PR TITLE
Return the real shelf title

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -362,8 +362,8 @@ def meta():
         except Exception as ex:
             ub.session.rollback()
             log.error("Error occurred: %s", ex)
-        
-        resp = {"shelf_id": shelf_id}
+
+        resp = {"shelf_id": shelf_id, "shelf_title": shelf_title}
         return resp
 
     log.info("Received metadata request: %s", request.args)

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -84,6 +84,7 @@ class TaskMetadataExtract(CalibreTask):
             response = requests.get(self.original_url, params={"current_user_name": self.current_user_name, "shelf_title": self.shelf_title})
             if response.status_code == 200:
                 self.shelf_id = response.json()["shelf_id"]
+                self.shelf_title = response.json()["shelf_title"]
             else:
                 log.error("Received unexpected status code %s while sending the shelf title to %s", response.status_code, self.original_url)
         except Exception as e:


### PR DESCRIPTION
This returns the shelf title. It is updated if another shelf is already name after the playlist title. The link to the shelf remains unchanged.