### PR TITLE
Prevent stuck videos from carrying over to next download session ["unavailable fragments" ?]

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -98,8 +98,9 @@ class TaskDownload(CalibreTask):
                             else:
                                 log.error("No error found in the database, likely the video failed due to unavailable fragments.")
                                 self.message = f"{self.media_url_link} failed to download: No path found in the database"
+                            media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                             conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
-                            conn.execute("DELETE FROM captions WHERE media_id = ?", (self.media_url,))
+                            conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
                             conn.commit()
                             return
                     except sqlite3.Error as db_error:

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -97,7 +97,7 @@ class TaskDownload(CalibreTask):
                                 self.message = f"{error[1]} failed to download: {error[0]}"
                             else:
                                 log.error("No error found in the database, likely the video failed due to unavailable fragments.")
-                                self.message = f"{self.media_url_link} failed to download: No path found in the database"
+                                self.message = f"{self.media_url_link} failed to download: No path or error found in the database (likely the video failed due to unavailable fragments?)"
                                 media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                                 conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
                                 conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -100,6 +100,7 @@ class TaskDownload(CalibreTask):
                                 self.message = f"{self.media_url_link} failed to download: No path found in the database"
                             conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
                             conn.execute("DELETE FROM captions WHERE media_id = ?", (self.media_url,))
+                            conn.commit()
                             return
                     except sqlite3.Error as db_error:
                         log.error("An error occurred while trying to connect to the database: %s", db_error)
@@ -116,6 +117,7 @@ class TaskDownload(CalibreTask):
                         # 2024-02-17: Dedup Design Evolving... https://github.com/iiab/calibre-web/pull/125
                         conn.execute("UPDATE media SET path = ? WHERE webpath = ?", (new_video_path, self.media_url))
                         conn.execute("UPDATE media SET webpath = ? WHERE path = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", new_video_path))
+                        conn.commit()
                         self.progress = 1.0
                     else:
                         log.error("Failed to send the requested file to %s", self.original_url)

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -96,7 +96,7 @@ class TaskDownload(CalibreTask):
                                 log.error("[xklb] An error occurred while trying to download %s: %s", error[1], error[0])
                                 self.message = f"{error[1]} failed to download: {error[0]}"
                             else:
-                                log.error("No error found in the database, likely the video failed due to unavailable fragments.")
+                                log.error("%s failed to download: No path or error found in the database (likely the video failed due to unavailable fragments?)", self.media_url)
                                 self.message = f"{self.media_url_link} failed to download: No path or error found in the database (likely the video failed due to unavailable fragments?)"
                                 media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                                 conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -95,6 +95,11 @@ class TaskDownload(CalibreTask):
                             if error:
                                 log.error("[xklb] An error occurred while trying to download %s: %s", error[1], error[0])
                                 self.message = f"{error[1]} failed to download: {error[0]}"
+                            else:
+                                log.error("No error found in the database, likely the video failed due to unavailable fragments.")
+                                self.message = f"{self.media_url_link} failed to download: No path found in the database"
+                            conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
+                            conn.execute("DELETE FROM captions WHERE media_id = ?", (self.media_url,))
                             return
                     except sqlite3.Error as db_error:
                         log.error("An error occurred while trying to connect to the database: %s", db_error)

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -117,7 +117,6 @@ class TaskDownload(CalibreTask):
                         # 2024-02-17: Dedup Design Evolving... https://github.com/iiab/calibre-web/pull/125
                         conn.execute("UPDATE media SET path = ? WHERE webpath = ?", (new_video_path, self.media_url))
                         conn.execute("UPDATE media SET webpath = ? WHERE path = ?", (f"{self.media_url}&timestamp={int(datetime.now().timestamp())}", new_video_path))
-                        conn.commit()
                         self.progress = 1.0
                     else:
                         log.error("Failed to send the requested file to %s", self.original_url)

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -124,8 +124,6 @@ class TaskDownload(CalibreTask):
                         log.error("Failed to send the requested file to %s", self.original_url)
                         self.message = f"{self.media_url_link} failed to download: {response.status_code} {response.reason}"
 
-                conn.close()
-
             except Exception as e:
                 log.error("An error occurred during the subprocess execution: %s", e)
                 self.message = f"{self.media_url_link} failed to download: {self.read_error_from_database()}"

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -124,6 +124,8 @@ class TaskDownload(CalibreTask):
                         log.error("Failed to send the requested file to %s", self.original_url)
                         self.message = f"{self.media_url_link} failed to download: {response.status_code} {response.reason}"
 
+                conn.close()
+
             except Exception as e:
                 log.error("An error occurred during the subprocess execution: %s", e)
                 self.message = f"{self.media_url_link} failed to download: {self.read_error_from_database()}"

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -98,10 +98,10 @@ class TaskDownload(CalibreTask):
                             else:
                                 log.error("No error found in the database, likely the video failed due to unavailable fragments.")
                                 self.message = f"{self.media_url_link} failed to download: No path found in the database"
-                            media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
-                            conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
-                            conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
-                            conn.commit()
+                                media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
+                                conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
+                                conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
+                                conn.commit()
                             return
                     except sqlite3.Error as db_error:
                         log.error("An error occurred while trying to connect to the database: %s", db_error)

--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -101,7 +101,6 @@ class TaskDownload(CalibreTask):
                                 media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                                 conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
                                 conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
-                                conn.commit()
                             return
                     except sqlite3.Error as db_error:
                         log.error("An error occurred while trying to connect to the database: %s", db_error)


### PR DESCRIPTION
Video failed due to unavailable fragments are not kept in the database. Those failed for other reasons are left but will not carry over the next download session.
 
Tested on Ubuntu 24.04 with #194 
![image](https://github.com/iiab/calibre-web/assets/16546989/47f2fb83-4226-40a5-bf77-ac9d72f7287f)