### PR TITLE
Adjust message to warn about problematic videos

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -167,6 +167,8 @@ class TaskMetadataExtract(CalibreTask):
                     media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                     conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
                     conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
+                else:
+                    self.message = f"{self.media_url_link} failed: An error occurred while trying to fetch the requested URLs."
                 self.stat = STAT_FAIL
 
             elif self.is_playlist:

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -160,8 +160,14 @@ class TaskMetadataExtract(CalibreTask):
             self._remove_shorts_from_db(conn)
             requested_urls = self._fetch_requested_urls(conn)
             if not requested_urls:
-                self.message = f"Failed to download {self.media_url_link} last time. Please submit the URL again to force a retry."
-                conn.execute("DELETE FROM media WHERE path = ?", (self.media_url,))
+                if self.unavailable:
+                    self.message = f"{self.media_url_link} failed: Video not available."
+                if error_message := conn.execute("SELECT error FROM media WHERE ? LIKE '%' || extractor_id || '%'", (self.media_url,)).fetchone()[0]:
+                    self.message = f"{self.media_url_link} failed previously with this error: {error_message}<br><br>To force a retry, submit the URL again."
+                    media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
+                    conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
+                    conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
+                    conn.commit()
                 self.stat = STAT_FAIL
 
             elif self.is_playlist:

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -162,7 +162,7 @@ class TaskMetadataExtract(CalibreTask):
             if not requested_urls:
                 if self.unavailable:
                     self.message = f"{self.media_url_link} failed: Video not available."
-                if error_message := conn.execute("SELECT error FROM media WHERE ? LIKE '%' || extractor_id || '%'", (self.media_url,)).fetchone()[0]:
+                elif error_message := conn.execute("SELECT error FROM media WHERE ? LIKE '%' || extractor_id || '%'", (self.media_url,)).fetchone()[0]:
                     self.message = f"{self.media_url_link} failed previously with this error: {error_message}<br><br>To force a retry, submit the URL again."
                     media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                     conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -167,7 +167,6 @@ class TaskMetadataExtract(CalibreTask):
                     media_id = conn.execute("SELECT id FROM media WHERE webpath = ?", (self.media_url,)).fetchone()[0]
                     conn.execute("DELETE FROM media WHERE webpath = ?", (self.media_url,))
                     conn.execute("DELETE FROM captions WHERE media_id = ?", (media_id,))
-                    conn.commit()
                 self.stat = STAT_FAIL
 
             elif self.is_playlist:

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -160,7 +160,7 @@ class TaskMetadataExtract(CalibreTask):
             self._remove_shorts_from_db(conn)
             requested_urls = self._fetch_requested_urls(conn)
             if not requested_urls:
-                self.message = f"{self.media_url_link} failed: Video not available."
+                self.message = f"Failed to download {self.media_url_link} last time. Please submit the URL again to force a retry."
                 conn.execute("DELETE FROM media WHERE path = ?", (self.media_url,))
                 self.stat = STAT_FAIL
 


### PR DESCRIPTION
Tested together with #193 

![image](https://github.com/iiab/calibre-web/assets/16546989/47f2fb83-4226-40a5-bf77-ac9d72f7287f)

Unavailable videos returns a different message:

![image](https://github.com/iiab/calibre-web/assets/16546989/7a0168da-1847-4154-bb84-cfe182124005)

Tested on Ubuntu 24.04
