### PR TITLE
Add --live flag to support downloading of "live" videos

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -81,7 +81,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}' --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live -o '${OUTTMPL}' ${VERBOSITY}"
+    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live --live-from-start -o '${OUTTMPL}' ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}'"
 else

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -81,7 +81,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}' --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs -o '${OUTTMPL}' ${VERBOSITY}"
+    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live -o '${OUTTMPL}' ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}'"
 else


### PR DESCRIPTION
This PR introduces `--live` so live videos can be downloaded. It was tested with a fork of xklb with the changes proposed in https://github.com/chapmanjacobd/library/pull/41

![image](https://github.com/iiab/calibre-web/assets/16546989/884ca794-7527-4f56-b0c3-d0f9682d91b7)
