### PR TITLE
Clear input field right after URL is submitted

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -203,6 +203,8 @@ $(document).ready(function() {
                 $("#mediaDownloadForm .error-message").text("Media download request failed.");
             }
         });
+
+        $("#mediaURL").val("");
     }
 
     // Handle Enter key press event in the input field
@@ -256,11 +258,6 @@ $(document).ready(function() {
         } else {
             $("#maxVideos").prop("disabled", false);
         }
-    });
-
-    // Clear the input field when the modal is shown
-    $("#mediaDownloadModal").on('shown.bs.modal', function() {
-        $("#mediaURL").val("");
     });
 
     /*


### PR DESCRIPTION
Clears the input field as requested by @avni in https://github.com/iiab/calibre-web/issues/181#issuecomment-2185342549.