### PR TITLE
Make image and videos uploads use the same data structure

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -93,6 +93,7 @@ def process(tmp_file_path, original_file_name, original_file_extension, rar_exec
         elif extension_upper in ['.MP4', '.WEBM', '.MKV']:
             meta = video_metadata(tmp_file_path, original_file_name, original_file_extension)
         elif extension_upper in ['.JPG', '.JPEG', '.PNG', '.GIF', '.SVG', '.WEBP']:
+            shutil.copyfile(tmp_file_path, os.path.splitext(tmp_file_path)[0] + '.cover.jpg')
             meta = image_metadata(tmp_file_path, original_file_name, original_file_extension)
 
     except Exception as ex:
@@ -351,7 +352,6 @@ def generate_video_cover(tmp_file_path):
         return None
 
 def image_metadata(tmp_file_path, original_file_name, original_file_extension):
-    shutil.copyfile(tmp_file_path, os.path.splitext(tmp_file_path)[0] + '.cover.jpg')
     meta = BookMeta(
         file_path=tmp_file_path,
         extension=original_file_extension,

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -307,21 +307,7 @@ def video_metadata(tmp_file_path, original_file_name, original_file_extension):
             log.warning('Cannot find the xklb database, using default metadata')
     else:
         generate_video_cover(tmp_file_path)
-        meta = BookMeta(
-            file_path=tmp_file_path,
-            extension=original_file_extension,
-            title=original_file_name,
-            author='Unknown',
-            cover=os.path.splitext(tmp_file_path)[0] + '.cover.jpg',
-            description='',
-            tags='',
-            series="",
-            series_id="",
-            languages="",
-            publisher="",
-            pubdate="",
-            identifiers=[])
-        return meta
+        return image_metadata(tmp_file_path, original_file_name, original_file_extension)
 
 # Yes shlex.quote() can help! But flags/options/switchs can still be dangerous:
 # https://stackoverflow.com/questions/49573852/is-python3-shlex-quote-safe


### PR DESCRIPTION
This makes code less redundant. Tested on Ubuntu 24.04 (LRN2). No feature change introduced.