### PR TITLE
Adjust message for formerly "live" videos

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -58,7 +58,7 @@ class TaskDownload(CalibreTask):
 
                 self.message = f"Downloading {self.media_url_link}..."
                 if self.live_status == "was_live":
-                    self.message += f" (This may take longer than expected due to the video was live for {self.duration})"
+                    self.message += f" (formerly live video, length/duration is {self.duration} seconds)"
                 while p.poll() is None:
                     self.end_time = datetime.now()
                     # Check if there's data available to read

--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -125,10 +125,10 @@ class TaskMetadataExtract(CalibreTask):
         return dict(sorted(requested_urls.items(), key=lambda item: item[1]["views_per_day"], reverse=True)[:min(MAX_VIDEOS_PER_DOWNLOAD, len(requested_urls))])
 
     def _add_download_tasks_to_worker(self, requested_urls):
-        for index, requested_url in enumerate(requested_urls.keys()):
+        for index, (requested_url, url_data) in enumerate(requested_urls.items()):
             task_download = TaskDownload(_("Downloading %(url)s...", url=requested_url),
                                          requested_url, self.original_url,
-                                         self.current_user_name, self.shelf_id)
+                                         self.current_user_name, self.shelf_id, duration=str(url_data["duration"]), live_status=url_data["live_status"])
             WorkerThread.add(self.current_user_name, task_download)
             num_requested_urls = len(requested_urls)
             total_duration = sum(url_data["duration"] for url_data in requested_urls.values())


### PR DESCRIPTION
Display a message to let the user know about potential long download when a formerly live video is requested.

Tested on Ubuntu 24.04 (LRN2)
![image](https://github.com/iiab/calibre-web/assets/16546989/6c5aba91-375a-4598-b7a3-656b52b975cf)
