### PR TITLE
Prevent live videos from carrying over subsequent download tasks

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -63,10 +63,10 @@ class TaskMetadataExtract(CalibreTask):
         try:
             cursor = conn.execute("PRAGMA table_info(media)")
             self.columns = [column[1] for column in cursor.fetchall()]
-            query = ("SELECT path, duration FROM media WHERE error IS NULL AND path LIKE 'http%'"
+            query = ("SELECT path, duration, live_status FROM media WHERE error IS NULL AND path LIKE 'http%' AND time_created > ?"
                      if "error" in self.columns
-                     else "SELECT path, duration FROM media WHERE path LIKE 'http%'")
-            rows = conn.execute(query).fetchall()
+                     else "SELECT path, duration, live_status FROM media WHERE path LIKE 'http%' AND time_created > ?")
+            rows = conn.execute(query, (int(self.start_time.timestamp()),)).fetchall()
             requested_urls = {}
             for path, duration in rows:
                 if duration is not None and duration > 0:


### PR DESCRIPTION
Upcoming and actually live videos are not being downloaded due to their duration being unknown. Records of these videos are kept in xklb-metadata.db. Unfortunately, these videos urls are caught in subsequent downloads tasks. We choose not to delete them in support of an eventual "download retry" feature. This PR prevents them from being carried over by cutting the selection treshold to the time the task was created. So any live or failed videos prior to this timestamp is ignored.

Fixes #202 

Tested on Ubuntu 24.04 (LRN2)

Before
https://private-user-images.githubusercontent.com/16546989/344163839-39c2ca8a-bbcd-4e0c-acab-439f4af6ba65.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAxOTQ4MjUsIm5iZiI6MTcyMDE5NDUyNSwicGF0aCI6Ii8xNjU0Njk4OS8zNDQxNjM4MzktMzljMmNhOGEtYmJjZC00ZTBjLWFjYWItNDM5ZjRhZjZiYTY1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzA1VDE1NDg0NVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTYzMzUzOTgxMzU3NTg4YTU4NzAwMTEwNjY5YTExY2I1NzA4ODQ1MzQxNjI1ZGQ3ZjIzNTQwMmJkNjgxODEzY2MmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.XFc0VWvD1h0olXx0yd1LEsnxmevpprhxNvyj6ETFSeA

After
![image](https://github.com/iiab/calibre-web/assets/16546989/856f3cca-deeb-47a5-82a6-b6537bac2ff5)
