### PR TITLE
Ensure progress is 100% on task success

### DIFF
--- a/cps/tasks/metadata_extract.py
+++ b/cps/tasks/metadata_extract.py
@@ -196,6 +196,7 @@ class TaskMetadataExtract(CalibreTask):
             self._add_download_tasks_to_worker(requested_urls)
         conn.close()
 
+        self.progress = 1.0
         self.stat = STAT_FINISH_SUCCESS
 
     @property


### PR DESCRIPTION
Quick task would sometimes report 0% on task success due to the polling not being able to report it fast enough before the subprocess exits. This PR ensures the 100% is always reported upon success.

Fixes #205

Tested on Ubuntu 24.04 (LRN2)
![image](https://github.com/iiab/calibre-web/assets/16546989/7e3b7b2d-992c-46fd-9c8c-d660b8fd04b1)
