### PR TITLE
Import shutil.move to recover from upstream change (janeczku@bc1c097) to cps/editbooks.py

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -23,7 +23,7 @@
 import os
 from datetime import datetime
 import json
-from shutil import copyfile
+from shutil import copyfile, move
 from uuid import uuid4
 from markupsafe import escape, Markup  # dependency of flask
 from functools import wraps


### PR DESCRIPTION
This PR imports shutil's `move` back which was [removed] by upstream changes.

Fixes #220 

Tested on Ubuntu 24.04 (LRN2)
![image](https://github.com/iiab/calibre-web/assets/16546989/25de334b-375d-4742-93a2-1b5049475cf4)
