### PR TITLE
Remove the scene detection filter

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -324,7 +324,7 @@ def generate_video_cover(tmp_file_path):
     ffmpeg_args = [
         ffmpeg_executable,
         '-i', tmp_file_path,
-        '-vf', 'fps=1,thumbnail,select=gt(scene\,0.1),scale=-1:720',  # apply filters to avoid black frames and scale
+        '-vf', 'fps=1,thumbnail,scale=-1:720',  # apply filters to avoid black frames and scale
         '-frames:v', '1',  # extract only one frame
         '-vsync', 'vfr',  # variable frame rate
         '-y',  # overwrite output file if it exists


### PR DESCRIPTION
Makes the video cover generation upon upload failsafe for some videos with little scene changes.

Tested on Ubuntu 24.04 (LRN2)
![image](https://github.com/user-attachments/assets/7b3ccfe5-273c-4391-9f31-dbacefcbf1da)


Fixes #214 