### PR TITLE
Increase fragment stuck timeout to 60 seconds [was 30s]

### DIFF
--- a/cps/tasks/download.py
+++ b/cps/tasks/download.py
@@ -54,7 +54,7 @@ class TaskDownload(CalibreTask):
                 complete_progress_cycle = 0
 
                 last_progress_time = datetime.now()
-                fragment_stuck_timeout = 30  # seconds
+                fragment_stuck_timeout = 60  # seconds
 
                 self.message = f"Downloading {self.media_url_link}..."
                 if self.live_status == "was_live":


### PR DESCRIPTION
This PR makes the detection of stuck videos less strict, giving more time before displaying an error message.