### PR TITLE
cps/editbooks.py: RENAME update_title_sort TO create_functions (IN move_mediafile) FOR PR #240

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -242,7 +242,7 @@ def meta():
         log.info("Processing file: {}".format(requested_file))
         try:
             modify_date = False
-            calibre_db.update_title_sort(config)
+            calibre_db.create_functions(config)
             calibre_db.session.connection().connection.connection.create_function(
                 "uuid4", 0, lambda: str(uuid4())
             )


### PR DESCRIPTION
@deldesir can you help explain why this appears to fix...

- #241

...arising from...

- PR #240 

...thereby realigning us with upsteam?  Thanks!

( Tested on Ubuntu 24.10, by clicking button "Download to IIAB" with video https://www.youtube.com/watch?v=BBceWqOhoiE )