### PR TITLE
Strengthen video ID match [PROBLEM: videos with square brackets in their title do not download]

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -269,7 +269,7 @@ def pdf_preview(tmp_file_path, tmp_dir):
 
 def video_metadata(tmp_file_path, original_file_name, original_file_extension):
     if '[' in original_file_name and ']' in original_file_name:
-        video_id = original_file_name.split('[')[1].split(']')[0]
+        video_id = original_file_name.split('[')[-1].split(']')[0]
         video_url = None
         if os.path.isfile(XKLB_DB_FILE):
             with sqlite3.connect(XKLB_DB_FILE) as conn:


### PR DESCRIPTION
As explained in https://github.com/iiab/calibre-web/issues/284#issuecomment-2480896020, IIAB Calibre-Web looks for video IDs inside square brackets ([...]) in the filenames. A video might have two sets of square brackets. This PR ensures video IDs are always correctly identified in the last set of square brackets. 

This is also [adjusted](https://github.com/iiab/calibre-web/pull/254/commits/f2a25704ae79dc145901288f3b6c54a2f58b24c6) in SQLAlchemy-related code refactoring.