### PR TITLE
Update Calibre-Web Integration Tests Documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,18 @@ Integration tests were added to this project, follow the steps below to set up a
    wget  -O app.db "https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db"
    ```
 
-1. Execute calibre web in background:
+1. Execute calibre web in background (NB: you must have two separate terminal windows open, one for running Calibre-Web in the background and one for tests):
    ```bash
    nohup python3 cps.py &
    ```
 
-1. Install tests requirements:
+1. Install tests requirements (NB: Open a separate terminal window, activate the Calibre-Web venv, and continue with the below steps):
 
    ```bash
    pip install -r integration-tests-requirements.txt
    ```
 
-1. Execute the tests:
+1. Execute the tests (NB: you must run the tests as a non-root user):
 
    If you want to watch the execution process, and the interaction with the browser:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Integration tests were added to this project, follow the steps below to set up a
    Ensure you have all required dependencies installed. Use the following commands:
 
    ```bash
+   cd /opt/iiab/calibre-web # cd into the directory where you have calibre-web cloned
    python3 -m venv calibre-web-env
    source calibre-web-env/bin/activate
    pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Integration tests were added to this project, follow the steps below to set up a
    Ensure you have all required dependencies installed. Use the following commands:
 
    ```bash
-   cd /opt/iiab/calibre-web    # cd into the directory where you have Calibre-Web cloned
+   cd /opt/iiab/calibre-web-py3    # cd into the directory where you have Calibre-Web cloned
    python3 -m venv calibre-web-env
    source calibre-web-env/bin/activate
    pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -141,36 +141,39 @@ We would like to thank all the [contributors](https://github.com/janeczku/calibr
 Integration tests were added to this project, follow the steps below to set up and execute the integration tests:
 
 ### Prerequisites
+
 1. **Install Chrome to enable Selenium testing**:
    e.g., Follow the instructions on this page to install Chrome for Ubuntu: https://linuxcapable.com/install-google-chrome-on-ubuntu-linux/
    
-1. **Install dependencies**:
+2. **Install dependencies**:
    Ensure you have all required dependencies installed. Use the following commands:
 
    ```bash
-   cd /opt/iiab/calibre-web # cd into the directory where you have calibre-web cloned
+   cd /opt/iiab/calibre-web    # cd into the directory where you have Calibre-Web cloned
    python3 -m venv calibre-web-env
    source calibre-web-env/bin/activate
    pip install -r requirements.txt
    ```
 
-1. Add the dummy database from IIAB project:
+3. Add the dummy database from IIAB project:
+
    ```bash
-   wget  -O app.db "https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db"
+   wget -O app.db https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db
    ```
 
-1. Execute calibre web in background (NB: you must have two separate terminal windows open, one for running Calibre-Web in the background and one for tests):
+4. Execute Calibre-Web in background: (NB: you must have two separate terminal windows open, one for running Calibre-Web in the background and one for tests)
+
    ```bash
    nohup python3 cps.py &
    ```
 
-1. Install tests requirements (NB: Open a separate terminal window, activate the Calibre-Web venv, and continue with the below steps):
+5. Install tests requirements: (NB: Open a separate terminal window, activate the Calibre-Web venv, and continue with the below steps)
 
    ```bash
    pip install -r integration-tests-requirements.txt
    ```
 
-1. Execute the tests (NB: you must run the tests as a non-root user):
+6. Execute the tests: (NB: you must run the tests as a non-root user)
 
    If you want to watch the execution process, and the interaction with the browser:
 
@@ -183,7 +186,6 @@ Integration tests were added to this project, follow the steps below to set up a
    ```
    HEADLESS=true pytest -s
    ```
-
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ Integration tests were added to this project, follow the steps below to set up a
    e.g., Follow the instructions on this page to install Chrome for Ubuntu: https://linuxcapable.com/install-google-chrome-on-ubuntu-linux/
    
 2. **Install dependencies**:
-   Ensure you have all required dependencies installed. Use the following commands:
+   Ensure you have all required dependencies installed.
+
+   First, install Calibre-Web following the instructions here: https://github.com/iiab/calibre-web/wiki#wrench-installation
+
+   Then, set up the python environment using the following commands:
 
    ```bash
    cd /opt/iiab/calibre-web-py3    # cd into the directory where you have Calibre-Web cloned
@@ -155,25 +159,25 @@ Integration tests were added to this project, follow the steps below to set up a
    pip install -r requirements.txt
    ```
 
-3. Add the dummy database from IIAB project:
+4. Add the dummy database from IIAB project:
 
    ```bash
    wget -O app.db https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db
    ```
 
-4. Execute Calibre-Web in background: (NB: you must have two separate terminal windows open, one for running Calibre-Web in the background and one for tests)
+5. Execute Calibre-Web in background: (NB: you must have two separate terminal windows open, one for running Calibre-Web in the background and one for tests)
 
    ```bash
    nohup python3 cps.py &
    ```
 
-5. Install tests requirements: (NB: Open a separate terminal window, activate the Calibre-Web venv, and continue with the below steps)
+6. Install tests requirements: (NB: Open a separate terminal window, activate the Calibre-Web venv, and continue with the below steps)
 
    ```bash
    pip install -r integration-tests-requirements.txt
    ```
 
-6. Execute the tests: (NB: you must run the tests as a non-root user)
+7. Execute the tests: (NB: you must run the tests as a non-root user)
 
    If you want to watch the execution process, and the interaction with the browser:
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ We would like to thank all the [contributors](https://github.com/janeczku/calibr
 Integration tests were added to this project, follow the steps below to set up and execute the integration tests:
 
 ### Prerequisites
-
+1. **Install Chrome to enable Selenium testing**:
+   e.g., Follow the instructions on this page to install Chrome for Ubuntu: https://linuxcapable.com/install-google-chrome-on-ubuntu-linux/
+   
 1. **Install dependencies**:
    Ensure you have all required dependencies installed. Use the following commands:
 


### PR DESCRIPTION
This PR includes updates to the `README.md` file to improve the instructions for setting up and executing integration tests. Specifically: 

- Make clear that you must be in the calibre-web dir before creating venv.
- Update integration tests doc to include Chrome prerequisite
- Clarify that Calibre-Web running in bg needs to be in separate terminal window 
- Note that tests must be executed as a non-root user. 

@Akatama notes that both nohup running in the bg and running the tests should be able to be in the same window, but neither of us could get that working. We had to have a separate terminal window open running Calibre-Web in the background.

**Related:** 
- https://github.com/iiab/calibre-web/pull/291
