### PR TITLE
Added Firefox install and Firefox test run with the current tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,43 +1,37 @@
 name: Integration tests
-run-name: Integration tests 
+run-name: Integration tests
 on: [push]
 jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Executing Integration tests"
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v4
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - uses: browser-actions/setup-chrome@v1
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
       - run: chrome --version
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: "Create python environment"
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@v1
+      - run: firefox --version
+      - name: Create Python environment
         run: |
-          python3 -m venv calibre-web-env 
-          source calibre-web-env/bin/activate     
+          python3 -m venv calibre-web-env
+          source calibre-web-env/bin/activate
       - name: Install Python dependencies for testing
         uses: py-actions/py-dependency-install@v4
         with:
-          path: "requirements.txt"
-      - name: "Download dummy database"
-        run: |
-          wget  -O app.db "https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db"
-      - name: "Debugging line"
-        run: |
-          ls -la 
-      - name: "Execute calibre web in background"
-        run: |
-          nohup python3 cps.py & 
-      - name: "Verify local website"
-        run: |
-          curl -L localhost:8083
+          path: requirements.txt
+      - name: Download dummy database
+        run: wget -O app.db https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db
+      - name: Execute Calibre-Web in background
+        run: nohup python3 cps.py &
+      - name: Verify local website
+        run: curl -L localhost:8083
       - name: Install Python dependencies for testing
         uses: py-actions/py-dependency-install@v4
         with:
-          path: "integration-tests-requirements.txt"
-      - name: Execute PyTest for Integration Tests 
-        run: |
-          HEADLESS=true pytest -s
+          path: integration-tests-requirements.txt
+      - name: Execute Integration Tests for Chrome
+        run: pytest -s --splinter-webdriver chrome --splinter-headless
+      - name: Execute Integration Tests for Firefox
+        run: pytest -s --splinter-webdriver firefox --splinter-headless

--- a/README.md
+++ b/README.md
@@ -59,77 +59,62 @@ Calibre-Web is a web app that offers a clean and intuitive interface for browsin
 
 1. NEW Install Instructions for IIAB Calibre-Web:
 
-   <https://github.com/iiab/calibre-web/wiki#wrench-installation>
+   https://github.com/iiab/calibre-web/wiki#wrench-installation
 
 2. Technical Background explaining Calibre-Web on Internet-in-a-Box (IIAB) :
 
-   <https://github.com/iiab/iiab/blob/master/roles/calibre-web/README.rst>
+   https://github.com/iiab/iiab/blob/master/roles/calibre-web/README.rst
 
 ### ~Installation via pip (recommended)~ (NOT FOR IIAB CALIBRE-WEB)
 
 1. **Create a virtual environment**: It’s essential to isolate your Calibre-Web installation to avoid dependency conflicts. You can create a virtual environment by running:
-
    ```
    python3 -m venv calibre-web-env
    ```
-
 2. **Activate the virtual environment**:
-
    ```
    source calibre-web-env/bin/activate
    ```
-
 3. **Install Calibre-Web**: Use pip to install the application:
-
    ```
    pip install calibreweb
    ```
-
 4. **Install optional features**: For additional functionality, you may need to install optional features. Refer to [this page](https://github.com/janeczku/calibre-web/wiki/Dependencies-in-Calibre-Web-Linux-and-Windows) for details on what can be installed.
 5. **Start Calibre-Web**: After installation, you can start the application with:
-
    ```
    cps
    ```
 
 *Note: Users of Raspberry Pi OS may encounter installation issues. If you do, try upgrading pip and/or installing cargo as follows:*
-
    ```
    ./venv/bin/python3 -m pip install --upgrade pip
    sudo apt install cargo
    ```
 
 ### Important Links
-
 - For additional installation examples, check the following:
-  - [Manual installation](https://github.com/janeczku/calibre-web/wiki/Manual-installation)
-  - [Linux Mint installation](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-in-Linux-Mint-19-or-20)
-  - [Cloud Provider setup](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-on-a-Cloud-Provider)
+   - [Manual installation](https://github.com/janeczku/calibre-web/wiki/Manual-installation)
+   - [Linux Mint installation](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-in-Linux-Mint-19-or-20)
+   - [Cloud Provider setup](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-on-a-Cloud-Provider)
 
 ## Quick Start
 
 0. Read the [NEW Install Instructions](#installation) above for IIAB Calibre-Web!
 1. ~**Access Calibre-Web**: Open your browser and navigate to:~
-
    ```
    http://localhost:8083
    ```
-
    ~or for the OPDS catalog:~
-
    ```
    http://localhost:8083/opds
    ```
-
 2. **Log in**: Use the default admin credentials:
    - **Username:** Admin
    - **Password:** changeme
 3. **Database Setup**: If you do not have a Calibre database, download a sample from:
-
    ```
    https://github.com/janeczku/calibre-web/raw/master/library/metadata.db
    ```
-
    Move it out of the Calibre-Web folder to avoid overwriting during updates.
 4. **Configure Calibre Database**: In the admin interface, set the `Location of Calibre database` to the path of the folder containing your Calibre library (where `metadata.db` is located) and click "Save".
 5. **Google Drive Integration**: For hosting your Calibre library on Google Drive, refer to the [Google Drive integration guide](https://github.com/janeczku/calibre-web/wiki/G-Drive-Setup#using-google-drive-integration).
@@ -140,8 +125,8 @@ Calibre-Web is a web app that offers a clean and intuitive interface for browsin
 - **Python Version**: Ensure you have Python 3.7 or newer.
 - **Imagemagick**: Required for cover extraction from EPUBs. Windows users may also need to install [Ghostscript](https://ghostscript.com/releases/gsdnld.html) for PDF cover extraction.
 - **Optional Tools**:
-  - **Calibre desktop program**: Recommended for on-the-fly conversion and metadata editing. Set the path to Calibre’s converter tool on the setup page.
-  - **Kepubify tool**: Needed for Kobo device support. Download the tool and place the binary in `/opt/kepubify` on Linux or `C:\Program Files\kepubify` on Windows.
+   - **Calibre desktop program**: Recommended for on-the-fly conversion and metadata editing. Set the path to Calibre’s converter tool on the setup page.
+   - **Kepubify tool**: Needed for Kobo device support. Download the tool and place the binary in `/opt/kepubify` on Linux or `C:\Program Files\kepubify` on Windows.
 
 ## Docker Images
 

--- a/README.md
+++ b/README.md
@@ -59,62 +59,77 @@ Calibre-Web is a web app that offers a clean and intuitive interface for browsin
 
 1. NEW Install Instructions for IIAB Calibre-Web:
 
-   https://github.com/iiab/calibre-web/wiki#wrench-installation
+   <https://github.com/iiab/calibre-web/wiki#wrench-installation>
 
 2. Technical Background explaining Calibre-Web on Internet-in-a-Box (IIAB) :
 
-   https://github.com/iiab/iiab/blob/master/roles/calibre-web/README.rst
+   <https://github.com/iiab/iiab/blob/master/roles/calibre-web/README.rst>
 
 ### ~Installation via pip (recommended)~ (NOT FOR IIAB CALIBRE-WEB)
 
 1. **Create a virtual environment**: It’s essential to isolate your Calibre-Web installation to avoid dependency conflicts. You can create a virtual environment by running:
+
    ```
    python3 -m venv calibre-web-env
    ```
+
 2. **Activate the virtual environment**:
+
    ```
    source calibre-web-env/bin/activate
    ```
+
 3. **Install Calibre-Web**: Use pip to install the application:
+
    ```
    pip install calibreweb
    ```
+
 4. **Install optional features**: For additional functionality, you may need to install optional features. Refer to [this page](https://github.com/janeczku/calibre-web/wiki/Dependencies-in-Calibre-Web-Linux-and-Windows) for details on what can be installed.
 5. **Start Calibre-Web**: After installation, you can start the application with:
+
    ```
    cps
    ```
 
 *Note: Users of Raspberry Pi OS may encounter installation issues. If you do, try upgrading pip and/or installing cargo as follows:*
+
    ```
    ./venv/bin/python3 -m pip install --upgrade pip
    sudo apt install cargo
    ```
 
 ### Important Links
+
 - For additional installation examples, check the following:
-   - [Manual installation](https://github.com/janeczku/calibre-web/wiki/Manual-installation)
-   - [Linux Mint installation](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-in-Linux-Mint-19-or-20)
-   - [Cloud Provider setup](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-on-a-Cloud-Provider)
+  - [Manual installation](https://github.com/janeczku/calibre-web/wiki/Manual-installation)
+  - [Linux Mint installation](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-in-Linux-Mint-19-or-20)
+  - [Cloud Provider setup](https://github.com/janeczku/calibre-web/wiki/How-To:-Install-Calibre-Web-on-a-Cloud-Provider)
 
 ## Quick Start
 
 0. Read the [NEW Install Instructions](#installation) above for IIAB Calibre-Web!
 1. ~**Access Calibre-Web**: Open your browser and navigate to:~
+
    ```
    http://localhost:8083
    ```
+
    ~or for the OPDS catalog:~
+
    ```
    http://localhost:8083/opds
    ```
+
 2. **Log in**: Use the default admin credentials:
    - **Username:** Admin
    - **Password:** changeme
 3. **Database Setup**: If you do not have a Calibre database, download a sample from:
+
    ```
    https://github.com/janeczku/calibre-web/raw/master/library/metadata.db
    ```
+
    Move it out of the Calibre-Web folder to avoid overwriting during updates.
 4. **Configure Calibre Database**: In the admin interface, set the `Location of Calibre database` to the path of the folder containing your Calibre library (where `metadata.db` is located) and click "Save".
 5. **Google Drive Integration**: For hosting your Calibre library on Google Drive, refer to the [Google Drive integration guide](https://github.com/janeczku/calibre-web/wiki/G-Drive-Setup#using-google-drive-integration).
@@ -125,8 +140,8 @@ Calibre-Web is a web app that offers a clean and intuitive interface for browsin
 - **Python Version**: Ensure you have Python 3.7 or newer.
 - **Imagemagick**: Required for cover extraction from EPUBs. Windows users may also need to install [Ghostscript](https://ghostscript.com/releases/gsdnld.html) for PDF cover extraction.
 - **Optional Tools**:
-   - **Calibre desktop program**: Recommended for on-the-fly conversion and metadata editing. Set the path to Calibre’s converter tool on the setup page.
-   - **Kepubify tool**: Needed for Kobo device support. Download the tool and place the binary in `/opt/kepubify` on Linux or `C:\Program Files\kepubify` on Windows.
+  - **Calibre desktop program**: Recommended for on-the-fly conversion and metadata editing. Set the path to Calibre’s converter tool on the setup page.
+  - **Kepubify tool**: Needed for Kobo device support. Download the tool and place the binary in `/opt/kepubify` on Linux or `C:\Program Files\kepubify` on Windows.
 
 ## Docker Images
 
@@ -136,51 +151,108 @@ Calibre-Web is a web app that offers a clean and intuitive interface for browsin
 
 We would like to thank all the [contributors](https://github.com/janeczku/calibre-web/graphs/contributors) and maintainers of Calibre-Web for their valuable input and dedication to the project. Your contributions are greatly appreciated.
 
-## Running integration tests
+## Integration tests
 
-Integration tests were added to this project, follow the steps below to set up and execute the integration tests:
+#### Test plans
 
-### Prerequisites
+You can find the current test plan under in the [features](features) directory. Currently, there is only one test plan, which is [basic_behavior.feature](features/basic_behavior.feature).  
 
-1. **Install dependencies**:
-   Ensure you have all required dependencies installed. Use the following commands:
+Here what the layout of an example test plan looks like looks like:
 
-   ```bash
-   python3 -m venv calibre-web-env
-   source calibre-web-env/bin/activate
-   pip install -r requirements.txt
+```
+Feature: Basic behavior 
+    Testing basic behavior like showing home page and login 
+
+    Scenario: Home Page 
+        Given Calibre-Web is running 
+        When I go to the home page 
+
+        Then I should not see the error message
+        And see homepage information
+```
+
+A scenario is a specific test. Depending on the test, some things are taken as given, when an action is performed, then a certain state is reached.
+
+#### How the tests are implemented
+
+The tests are implemented using pytest-splinter, pytest-bdd and Selenium. The gist of all of this is to say that these are tests using [behavior-driven development](https://en.wikipedia.org/wiki/Behavior-driven_development). Pytest-splinter is the main driver of the tests, it is what is really driving the browser through the use of Selenium.
+
+Currently, we are limited to using Firefox and Chrome as a result of Splinter (a dependency of pytest-splinter) not supporting Chromium. If this were to change in the future though, we would probably rather use Chromium over Chrome as that is the default browser used with Raspberry Pi.
+
+You can see tests in the [/tests/functional](tests/functional) directory. Currently there is only one test file, [test_basic_behavior.py](tests/functional/test_basic_behavior.py).  
+
+Here is an example of one test:
+
+```
+@scenario('basic_behavior.feature', 'Home Page')
+def test_home_page():
+    """Home Page."""
+
+
+@given('Calibre-Web is running')
+def _(step_context):
+    """Calibre-Web is running."""
+    step_context['ip_address'] = 'localhost:8083'
+
+
+@when('I go to the home page')
+def _(browser, step_context):
+    """I go to the home page."""
+    url = urljoin("".join(['http://', str(step_context['ip_address'])]), '/')
+    browser.visit(url)
+
+
+@then('I should not see the error message')
+def _(browser, step_context):
+    """I should not see the error message."""
+
+@then('see homepage information')
+def _(browser):
+    """see homepage information."""
+    print("!!!!!!!")
+    print(browser.title)
+    print(browser.url)
+    print("!!!!!!!")
+    assert browser.is_text_present('Books'), 'Book test'
+```
+
+If you compare this test to the test I showed you in this test plan, then you will see that is pretty much exactly the same. Especially pay attention to the fixtures (the lines that begin with @).
+
+#### Prerequisites
+
+1. **Install Chrome and/or Firefox to enable Selenium testing**:
+
+    - [Install Chrome for Ubuntu](https://linuxcapable.com/install-google-chrome-on-ubuntu-linux/) and/or
+
+    - [Install Firefox](https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended) [NB: If you are on Ubuntu Deskop you must remove the Firefox Snap with `sudo snap remove firefox`, or else the tests will fail]
+
+2. **Enter into the directory where Calibre-Web is located**:
+
+    ```
+    cd /usr/local/calibre-web-py3
+    ```
+
+3. Install the integration test requirements in the same virtual environment:
+
    ```
-
-1. Add the dummy database from IIAB project:
-   ```bash
-   wget  -O app.db "https://github.com/iiab/iiab/raw/refs/heads/master/roles/calibre-web/files/app.db"
-   ```
-
-1. Execute calibre web in background:
-   ```bash
-   nohup python3 cps.py &
-   ```
-
-1. Install tests requirements:
-
-   ```bash
    pip install -r integration-tests-requirements.txt
    ```
 
-1. Execute the tests:
+#### Running the tests
 
-   If you want to watch the execution process, and the interaction with the browser:
-
-   ```
-   HEADLESS=false pytest -s
-   ```
-
-   And you can just run headless:
+   If you want to watch the test run
 
    ```
-   HEADLESS=true pytest -s
+   pytest -s --splinter-webdriver chrome
    ```
 
+   And/or you can just run headless:
+
+   ```
+   pytest -s --splinter-webdriver chrome --splinter-headless
+```
+
+To run the tests with the Firefox browser instead, replace chrome with firefox.
 
 ## Contact
 

--- a/features/basic_behavior.feature
+++ b/features/basic_behavior.feature
@@ -2,14 +2,14 @@ Feature: Basic behavior
     Testing basic behavior like showing home page and login 
 
     Scenario: Home Page 
-        Given Calibre web is running 
+        Given Calibre-Web is running 
         When I go to the home page 
 
         Then I should not see the error message
         And see homepage information
 
     Scenario: Login 
-        Given I visit the calibre web homepage 
+        Given I visit the Calibre-Web homepage 
         When I login with valid credentials
 
         Then I should see the success message

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 bdd_features_base_dir = features/
+testpaths = tests/functional
+filterwarnings = ignore::DeprecationWarning

--- a/tests/functional/test_basic_behavior.py
+++ b/tests/functional/test_basic_behavior.py
@@ -1,4 +1,5 @@
 """Basic behavior feature tests."""
+
 import pytest
 from pytest_bdd import (
     given,
@@ -7,90 +8,107 @@ from pytest_bdd import (
     when,
 )
 
-import os
-import subprocess 
 from urllib.parse import urljoin
-import time
+from selenium import webdriver
 
-@pytest.fixture(scope='session')
-def splinter_headless():
-    """Override splinter headless option."""
-    if os.environ['HEADLESS'] == "true":
-        return True
+
+@pytest.fixture(scope="session")
+def splinter_driver_kwargs(splinter_webdriver):
+    """Override Chrome WebDriver options"""
+    if splinter_webdriver == "chrome":
+        chrome_options = webdriver.ChromeOptions()
+
+        # List of Chromium Command Line Switches
+        # https://peter.sh/experiments/chromium-command-line-switches/
+        chrome_options.add_argument("--no-sandbox")
+
+        return {"options": chrome_options}
+
+    elif splinter_webdriver == "firefox":
+        firefox_options = webdriver.FirefoxOptions()
+        return {"options": firefox_options}
     else:
-        return False 
+        raise ValueError(
+            "Invalid browser passed to --splinter_Wewbdriver. Only Chrome and Firefox are allowed"
+        )
 
-@pytest.fixture(scope='session')
-def splinter_webdriver():
-    """Override splinter webdriver name."""
-    return 'chrome'
 
 @pytest.fixture
 def step_context():
     """Fixture to save information to use through steps."""
     return {}
 
-@scenario('basic_behavior.feature', 'Home Page')
+
+@scenario("basic_behavior.feature", "Home Page")
 def test_home_page():
     """Home Page."""
 
 
-@given('Calibre web is running')
+@given("Calibre-Web is running")
 def _(step_context):
-    """Calibre web is running."""
-    step_context['ip_address'] = 'localhost:8083'
+    """Calibre-Web is running."""
+    step_context["ip_address"] = "localhost:8083"
 
 
-@when('I go to the home page')
+@when("I go to the home page")
 def _(browser, step_context):
     """I go to the home page."""
-    url = urljoin("".join(['http://', str(step_context['ip_address'])]), '/')
+    url = urljoin("".join(["http://", str(step_context["ip_address"])]), "/")
     browser.visit(url)
 
 
-@then('I should not see the error message')
+@then("I should not see the error message")
 def _(browser, step_context):
     """I should not see the error message."""
 
-@then('see homepage information')
+
+@then("see homepage information")
 def _(browser):
     """see homepage information."""
     print("!!!!!!!")
     print(browser.title)
     print(browser.url)
     print("!!!!!!!")
-    assert browser.is_text_present('Books'), 'Book test'
+    assert browser.is_text_present("Books"), "Book test"
 
-@scenario('basic_behavior.feature', 'Login')
+
+@scenario("basic_behavior.feature", "Login")
 def test_login():
     """Login."""
 
 
-@given('I visit the calibre web homepage')
+@given("I visit the Calibre-Web homepage")
 def _(browser, step_context):
-    """I visit the calibre web homepage."""
-    step_context['ip_address'] = 'localhost:8083'
-    url = urljoin("".join(['http://', str(step_context['ip_address'])]), '/')
+    """I visit the Calibre-Web homepage."""
+    step_context["ip_address"] = "localhost:8083"
+    url = urljoin("".join(["http://", str(step_context["ip_address"])]), "/")
     browser.visit(url)
 
 
-@when('I login with valid credentials')
+@when("I login with valid credentials")
 def _(browser, step_context):
     """I login with valid credentials."""
-    browser.fill('username', 'Admin')
-    browser.fill('password', 'changeme')
-    button = browser.find_by_name('submit')
+    guest = browser.find_by_id("top_user")
+    guest.click()
+    browser.fill("username", "Admin")
+    browser.fill("password", "changeme")
+    button = browser.find_by_name("submit")
     # Interact with elements
     button.click()
 
 
-@then('I should see the success message')
+@then("I should see the success message")
 def _(browser, step_context):
     """I should see the success message."""
-    assert browser.is_text_present('You are now logged in as:'), 'Login successful'
+    assert browser.is_text_present("You are now logged in as:"), "Login successful"
 
-@then('see the information for logged users')
+
+@then("see the information for logged users")
 def _(browser):
     """see the information for logged users"""
-    assert browser.is_text_present('Books'), 'Expected "Books" text to be visible on the home page' 
-    assert browser.is_text_present('Download to IIAB'), 'Expected "Download to IIAB" button for logged users' 
+    assert browser.is_text_present("Books"), (
+        'Expected "Books" text to be visible on the home page'
+    )
+    assert browser.is_text_present("Download to IIAB"), (
+        'Expected "Download to IIAB" button for logged users'
+    )


### PR DESCRIPTION
There were a few changes to allow this to happen.

First, @avni and I noticed that the second test was failing, so I added the following lines:
```
    guest = browser.find_by_id('top_user')
    guest.click()
```
All this does is click on the 'Guest' picture on the top right of the screen so we can go to the login page.

Next, I removed this code:

```
@pytest.fixture(scope='session')
def splinter_webdriver():
    """Override splinter webdriver name."""
    return 'chrome'
```


This forces the tests to run only in Chrome. Of course, without this this means the tests won't run at all, but we have an argument we can pass on the command line to allow us to pick the browser we want to run tests with, like this:

'''
HEADLESS=true pytest -s --splinter-webdriver chrome
'''

This will run the tests as normal. If you replace chrome with firefox, then you will run the tests in Firefox instead.

Lastly, I made some changes to workflows/integration-test.yml. I removed a lot of lines that didn't do anything, although I can add them back in. The main things I added are:

- We install Firefox and check its version
- At the end of the workflow, we run both HEADLESS=true pytest -s --splinter-webdriver chrome and HEADLESS=true pytest -s --splinter-webdriver firefox

@holta @thotmx

Let me know if you have any questions or concerns. I would've preferred to find a way to have splinter_webdriver() return both chrome and firefox so all the tests could just run, but I couldn't find a way to do that.