### PR TITLE
Add explicit '=' to some lb args to avoid parse error

### DIFF
--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -24,6 +24,7 @@ OUTTMPL="${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id
 FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
 # These options are being passed straight to yt-dlp. So to avoid parsing errors, you must include the "=".
+# For info on why we are strict about this, see #267 https://github.com/iiab/calibre-web/issues/267
 YT_DLP_OPTIONS="--write-thumbnail --live --live-from-start -o='${OUTTMPL}' ${FORMAT_OPTIONS}"
 
 

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -20,8 +20,9 @@ VERBOSITY="-vv"
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
-# FORMAT_OPTIONS="--format-sort size"
-FORMAT_OPTIONS="--format best --format-sort 'tbr~1000'"
+# FORMAT_OPTIONS="--format-sort=size"
+# These options are being passed straght to yt-dlp. So to avoid parsing errors, you must include the "=".
+FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
 PATTERNS=(
     "downloading*"
@@ -81,7 +82,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}' --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live --live-from-start -o '${OUTTMPL}' ${VERBOSITY}"
+    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live --live-from-start -o='${OUTTMPL}' ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}'"
 else

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -6,8 +6,9 @@ URL_OR_SEARCH_TERM="$2"
 LOG_FILE="/var/log/xklb.log"
 XKLB_DB_FILE="/library/calibre-web/xklb-metadata.db"
 TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
-# outtmpl explanation:
-# https://github.com/yt-dlp/yt-dlp#output-template
+
+#OUTTMPL refers to yt-dlp's "OUTPUT TEMPLATE". This is a filepath with regex that can interpret attributes about the video. It enables things like a file structure sorted by Youtube Channel, or embedding metadata in the filename of the video. It is also mentioned in the "yt-dlp --help" menu. See https://github.com/yt-dlp/yt-dlp#output-template for more info.
+# Additional uses of the OUTPUT TEMPLATE:
 # https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L385-L388
 # https://github.com/chapmanjacobd/library/blob/e682ac20f5dcc4fa94238b57931f4705b9515059/xklb/createdb/tube_backend.py#L508-L523
 # /library/downloads/calibre-web/                                                                         (TMP_DOWNLOADS_DIR)

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -22,9 +22,10 @@ VERBOSITY="-vv"
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
 # FORMAT_OPTIONS="--format-sort=size"
-# These options are being passed straght to yt-dlp. So to avoid parsing errors, you must include the "=".
 FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
+# These options are being passed straight to yt-dlp. So to avoid parsing errors, you must include the "=".
+YT_DLP_OPTIONS="-o='${OUTTMPL} ${FORMAT_OPTIONS} '"
 PATTERNS=(
     "downloading*"
     "\[https://.*\]:*"
@@ -83,7 +84,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}' --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' ${FORMAT_OPTIONS} --write-thumbnail --subs --live --live-from-start -o='${OUTTMPL}' ${VERBOSITY}"
+    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' --write-thumbnail --subs --live --live-from-start ${YT_DLP_OPTIONS} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}'"
 else

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -17,7 +17,6 @@ TMP_DOWNLOADS_DIR="/library/downloads/calibre-web"
 #         ├── How does an air conditioner actually work？ - Anna Rothschild_224.59k_[6sSDXurPX-s].mp4     ([video file] title + view_count + video_id + extension)
 #         └── How does an air conditioner actually work？ - Anna Rothschild_224.59k_[6sSDXurPX-s].webp    ([thumbnail] title + view_count + video_id + extension)
 OUTTMPL="${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id)s/%(title).170B_%(view_count)3.2D_[%(id).64B].%(ext)s"
-VERBOSITY="-vv"
 
 # Or download largest possible HD-style / UltraHD videos, to try to force
 # out-of-memory "502 Bad Gateway" for testing of issues like #37 and #79
@@ -26,6 +25,9 @@ FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
 # These options are being passed straight to yt-dlp. So to avoid parsing errors, you must include the "=".
 YT_DLP_OPTIONS="-o='${OUTTMPL} ${FORMAT_OPTIONS} '"
+
+VERBOSITY="-vv"
+
 PATTERNS=(
     "downloading*"
     "\[https://.*\]:*"

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -24,7 +24,7 @@ OUTTMPL="${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id
 FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
 # These options are being passed straight to yt-dlp. So to avoid parsing errors, you must include the "=".
-YT_DLP_OPTIONS="-o='${OUTTMPL}' ${FORMAT_OPTIONS}"
+YT_DLP_OPTIONS="--write-thumbnail --live --live-from-start -o='${OUTTMPL}' ${FORMAT_OPTIONS}"
 
 
 VERBOSITY="-vv"
@@ -87,7 +87,7 @@ log "Info" "Using yt-dlp $(yt-dlp --version)"
 if [[ $XKLB_INTERNAL_CMD == "tubeadd" ]]; then
     xklb_full_cmd="lb tubeadd '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}' --force ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "dl" ]]; then
-    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' --write-thumbnail --subs --live --live-from-start ${YT_DLP_OPTIONS} ${VERBOSITY}"
+    xklb_full_cmd="lb dl '${XKLB_DB_FILE}' --video --search '${URL_OR_SEARCH_TERM}' --subs ${YT_DLP_OPTIONS} ${VERBOSITY}"
 elif [[ $XKLB_INTERNAL_CMD == "search" ]]; then
     xklb_full_cmd="lb search '${XKLB_DB_FILE}' '${URL_OR_SEARCH_TERM}'"
 else

--- a/scripts/lb-wrapper
+++ b/scripts/lb-wrapper
@@ -24,7 +24,8 @@ OUTTMPL="${TMP_DOWNLOADS_DIR}/%(extractor_key,extractor)s/%(uploader,uploader_id
 FORMAT_OPTIONS="--format=best --format-sort='tbr~1000'"
 
 # These options are being passed straight to yt-dlp. So to avoid parsing errors, you must include the "=".
-YT_DLP_OPTIONS="-o='${OUTTMPL} ${FORMAT_OPTIONS} '"
+YT_DLP_OPTIONS="-o='${OUTTMPL}' ${FORMAT_OPTIONS}"
+
 
 VERBOSITY="-vv"
 


### PR DESCRIPTION
Closes #267 
This is a very basic pull request. (Presumably) Because of changes in recent python versions' argparse() function, lb can only process cli arg tokens that start with "--". 

So I combined all the cli options and those option's arguments into one token with "="

For example "--format best" is 2 tokens, and "best" does not start with "--", so it gets parsed wrongly. Therefore I combined it into "--format=best".

This is originally @chapmanjacobd 's idea.