### PR TITLE
Added Integration Tests to iiab-install-smoke-test.yml

### DIFF
--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -48,10 +48,14 @@ jobs:
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
       - run: firefox --version
+      - name: Activate virtual environment
+        run: source bin/activate
+        working-directory: /usr/local/calibre-web-py3
+      - name: Install Python dependencies for testing
+        uses: py-actions/py-dependency-install@v4
       - name: Install depdenencies and run tests on Firefox
         run: |
           sudo su
           source bin/activate
-          pip install -r integration-tests-requirements.txt
           pytest -s --splinter-webdriver firefox --splinter-headless
         working-directory: /usr/local/calibre-web-py3

--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -53,6 +53,8 @@ jobs:
         working-directory: /usr/local/calibre-web-py3
       - name: Install Python dependencies for testing
         uses: py-actions/py-dependency-install@v4
+        with:
+          path: /usr/local/calibre-web-py3/integration-tests-requirements.txt
       - name: Install depdenencies and run tests on Firefox
         run: |
           sudo su

--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -45,3 +45,13 @@ jobs:
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Install Ansible
       - run: sudo ./iiab-install                    # Install IIAB!
         working-directory: /opt/iiab/iiab/
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@v1
+      - run: firefox --version
+      - name: Install depdenencies and run tests on Firefox
+        run: |
+          sudo su
+          source bin/activate
+          pip -r integration-tests-requirements.txt
+          pytest -s --splinter-webdriver firefox --splinter-headless
+        working-directory: /usr/local/calibre-web-py3

--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -55,9 +55,9 @@ jobs:
         uses: py-actions/py-dependency-install@v4
         with:
           path: /usr/local/calibre-web-py3/integration-tests-requirements.txt
-      - name: Install depdenencies and run tests on Firefox
-        run: |
-          sudo su
-          source bin/activate
-          pytest -s --splinter-webdriver firefox --splinter-headless
+      - name: Execute Integration Tests for Firefox
+        # Note that there are issues with creating the cache path for pytest, which results in the below warning.
+        # PytestCacheWarning: could not create cache path /usr/local/calibre-web-py3/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/usr/local/calibre-web-py3/pytest-cache-files-su2iy_u0'
+        # The tests pass, and -p no:cacheprovider makes it so the warning is not displayed
+        run: pytest -p no:cacheprovider -s --splinter-webdriver firefox --splinter-headless
         working-directory: /usr/local/calibre-web-py3

--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -52,6 +52,6 @@ jobs:
         run: |
           sudo su
           source bin/activate
-          pip -r integration-tests-requirements.txt
+          pip install -r integration-tests-requirements.txt
           pytest -s --splinter-webdriver firefox --splinter-headless
         working-directory: /usr/local/calibre-web-py3


### PR DESCRIPTION
Currently it is only running with Firefox. Since we're just trying to confirm that the IIAB install was successful, I figured running both would just make the workflow even more complicated. However, if we decide that Google Chrome is better to run the tests on, then we can do that instead.

There was some kind of permissions issue - Pytest likes to cache some stuff during the test runs. To be clear, both tests still passed, but I didn't like the warning gumming up the output. Especially if we looked at this a year from now, we might forget that it was just pytest complaining about something. The fix I have put in now is to call pytest with ` -p no:cacheprovider`. The caching wouldn't matter anyway since we are running this as a GitHub Action workflow.

Whatever permissions issue, it appears to be unique to the GitHub Actions runner VM, as I did not run into that warning when I made the test work with sudo back in PR #311

@holta 