### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/iiab-install-smoke-test.yml
+++ b/.github/workflows/iiab-install-smoke-test.yml
@@ -45,6 +45,8 @@ jobs:
       - run: sudo /opt/iiab/iiab/scripts/ansible    # Install Ansible
       - run: sudo ./iiab-install                    # Install IIAB!
         working-directory: /opt/iiab/iiab/
+      - name: Verify local website
+        run: curl -L localhost:8083
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
       - run: firefox --version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration tests
 run-name: Integration tests
-on: [push]
+on: [push, pull_request]
 jobs:
   integration-test-chrome:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There are two main changes here. 

1. Added a curl -L localhost:8083 step to iiab-install-smoke-test.yml. Its a simple check and adds pretty much no time to the whole workflow run, but will make it easier to diagnose issues like the one we saw earlier today.

2.  Modified the condition when integration-tests.yml runs from on: push to on: [push, pull_request]. I don't remember if we had a specific reason we did this in the past, but the run is really quick, so it will finish before iiab-install-smoke-test.yml finishes anyway.

I think that second item could be removed if necessary. Let me know, @holta 