### PR TITLE
Sync with upstream

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -349,8 +349,9 @@ def list_users():
         if sort not in ub.User.__table__.columns.keys():
             sort = "id"
     order = request.args.get("order", "").lower()
-
     if sort != "state" and order:
+        if not order in ["asc", "desc"]:
+            order = "asc"
         order = text(sort + " " + order)
     elif not state:
         order = ub.User.id.asc()

--- a/cps/basic.py
+++ b/cps/basic.py
@@ -19,7 +19,6 @@
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from cps.pagination import Pagination
 from flask import Blueprint
 from flask_babel import gettext as _
 from flask_babel import get_locale

--- a/cps/clean_html.py
+++ b/cps/clean_html.py
@@ -35,7 +35,7 @@ def clean_string(unsafe_text, book_id=0):
     try:
         if bleach:
             allowed_tags = list(ALLOWED_TAGS)
-            allowed_tags.extend(["p", "span", "div", "pre", "br", "h1", "h2", "h3", "h4", "h5", "h6"])
+            allowed_tags.extend(["p", "span", "div", "pre", "br", "h1", "h2", "h3", "h4", "h5", "h6", "img"])
             safe_text = clean_html(unsafe_text, tags=set(allowed_tags))
         else:
             safe_text = clean_html(unsafe_text)

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -328,7 +328,7 @@ class ConfigSQL(object):
         for k, v in self.__dict__.items():
             if k[0] != '_' and not k.endswith("_e") and not k == "cli" \
                     and 'api' not in k.lower() and 'token' not in k.lower() \
-                    and 'secret' not in k.lower()
+                    and 'secret' not in k.lower():
                 storage[k] = v
         return storage
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -326,7 +326,9 @@ class ConfigSQL(object):
     def to_dict(self):
         storage = {}
         for k, v in self.__dict__.items():
-            if k[0] != '_' and not k.endswith("_e") and not k == "cli" and 'api' not in k.lower():
+            if k[0] != '_' and not k.endswith("_e") and not k == "cli" \
+                    and 'api' not in k.lower() and 'token' not in k.lower() \
+                    and 'secret' not in k.lower()
                 storage[k] = v
         return storage
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -583,6 +583,7 @@ def get_encryption_key(key_path):
         try:
             with open(key_file, "wb") as f:
                 f.write(key)
+            os.chmod(key_file, 0o600)
         except PermissionError as e:
             error = e
     return key, error

--- a/cps/db.py
+++ b/cps/db.py
@@ -640,8 +640,8 @@ class CalibreDB:
                                          connect_args={'check_same_thread': False},
                                          poolclass=StaticPool)
             with check_engine.begin() as connection:
-                connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
-                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
+                connection.execute(text("attach database '{}' as calibre;".format(dbpath.replace("'", "''"))))
+                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path.replace("'", "''"))))
                 local_session = scoped_session(sessionmaker())
                 local_session.configure(bind=connection)
                 database_uuid = local_session().query(Library_Id).one_or_none()
@@ -694,8 +694,8 @@ class CalibreDB:
                                        poolclass=StaticPool)
             with engine.begin() as connection:
                 connection.execute(text('PRAGMA cache_size = 10000;'))
-                connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
-                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
+                connection.execute(text("attach database '{}' as calibre;".format(dbpath.replace("'", "''"))))
+                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path.replace("'", "''"))))
 
             conn = engine.connect()
             # conn.text_factory = lambda b: b.decode(errors = 'ignore') possible fix for #1302

--- a/cps/db.py
+++ b/cps/db.py
@@ -449,7 +449,16 @@ class Books(Base):
 
     @property
     def atom_timestamp(self):
-        return self.timestamp.strftime('%Y-%m-%dT%H:%M:%S+00:00') or ''
+        # OPDS atom:updated is defined as "the most recent instant in time
+        # when the entry was modified". Books.timestamp is the date added and
+        # never changes after import, so metadata and cover edits were
+        # invisible to OPDS sync clients. Use last_modified, which Calibre
+        # updates on every metadata or cover change; fall back to timestamp
+        # only if last_modified happens to be missing.
+        t = self.last_modified or self.timestamp
+        if t is None:
+            return ''
+        return t.strftime('%Y-%m-%dT%H:%M:%S+00:00') or ''
 
 
 class CustomColumns(Base):

--- a/cps/epub.py
+++ b/cps/epub.py
@@ -175,7 +175,7 @@ def parse_epub_cover(ns, tree, epub_zip, cover_path, tmp_file_path):
     for cs in cover_section:
         if cs.endswith('.xhtml') or cs.endswith('.html'):
             markup = epub_zip.read(os.path.join(cover_path, cs))
-            markup_tree = etree.fromstring(markup)
+            markup_tree = etree.fromstring(markup, parser=etree.XMLParser(resolve_entities=False, no_network=True))
             # no matter xhtml or html with no namespace
             img_src = markup_tree.xpath("//*[local-name() = 'img']/@src")
             # Alternative image source

--- a/cps/epub_helper.py
+++ b/cps/epub_helper.py
@@ -53,16 +53,20 @@ def updateEpub(src, dest, filename, data, ):
         zf.writestr(filename, data)
 
 
+# Safe parser: disable entity resolution and network access to prevent XXE attacks
+_safe_parser = etree.XMLParser(resolve_entities=False, no_network=True)
+
+
 def get_content_opf(file_path, ns=None):
     if ns is None:
         ns = default_ns
     epubZip = zipfile.ZipFile(file_path)
     txt = epubZip.read('META-INF/container.xml')
-    tree = etree.fromstring(txt)
+    tree = etree.fromstring(txt, parser=_safe_parser)
     cf_name = tree.xpath('n:rootfiles/n:rootfile/@full-path', namespaces=ns)[0]
     cf = epubZip.read(cf_name)
 
-    return etree.fromstring(cf), cf_name
+    return etree.fromstring(cf, parser=_safe_parser), cf_name
 
 
 def create_new_metadata_backup(book,  custom_columns, export_language, translated_cover_name, lang_type=3):

--- a/cps/fb2.py
+++ b/cps/fb2.py
@@ -20,6 +20,9 @@ from lxml import etree
 
 from .constants import BookMeta
 
+# Safe parser: disable entity resolution and network access to prevent XXE attacks
+_safe_parser = etree.XMLParser(resolve_entities=False, no_network=True)
+
 
 def get_fb2_info(tmp_file_path, original_file_extension):
 
@@ -29,7 +32,7 @@ def get_fb2_info(tmp_file_path, original_file_extension):
     }
 
     fb2_file = open(tmp_file_path, encoding="utf-8")
-    tree = etree.fromstring(fb2_file.read().encode())
+    tree = etree.fromstring(fb2_file.read().encode(), parser=_safe_parser)
 
     authors = tree.xpath('/fb:FictionBook/fb:description/fb:title-info/fb:author', namespaces=ns)
 

--- a/cps/gdrive.py
+++ b/cps/gdrive.py
@@ -140,7 +140,7 @@ try:
             if response:
                 dbpath = os.path.join(config.config_calibre_dir, "metadata.db").encode()
                 if not response['deleted'] and response['file']['title'] == 'metadata.db' \
-                  and response['file']['md5Checksum'] != hashlib.md5(dbpath):  # nosec
+                  and response['file']['md5Checksum'] != hashlib.md5(dbpath).hexdigest():  # nosec
                     tmp_dir = get_temp_dir()
 
                     log.info('Database file updated')

--- a/cps/jinjia.py
+++ b/cps/jinjia.py
@@ -30,6 +30,7 @@ from uuid import uuid4
 from flask import Blueprint, request, url_for, g
 from flask_babel import format_date
 from .cw_login import current_user
+from .clean_html import clean_string as html_clean_string
 
 from . import constants, logger
 
@@ -181,3 +182,9 @@ def contains_music(book_formats):
         if format.format.lower() in g.constants.EXTENSIONS_AUDIO:
             result = True
     return result
+
+@jinjia.app_template_filter('clean_string')
+def clean_string(unsafe_text):
+    return html_clean_string(unsafe_text)
+
+

--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -81,6 +81,8 @@ kobo_auth = Blueprint("kobo_auth", __name__, url_prefix="/kobo_auth")
 @kobo_auth.route("/generate_auth_token/<int:user_id>")
 @user_login_required
 def generate_auth_token(user_id):
+    if current_user.id != user_id and not current_user.role_admin():
+        abort(403)
     warning = False
     host_list = request.host.rsplit(':')
     if len(host_list) == 1:
@@ -123,6 +125,8 @@ def generate_auth_token(user_id):
 @kobo_auth.route("/deleteauthtoken/<int:user_id>", methods=["POST"])
 @user_login_required
 def delete_auth_token(user_id):
+    if current_user.id != user_id and not current_user.role_admin():
+        abort(403)
     # Invalidate any previously generated Kobo Auth token for this user
     ub.session.query(ub.RemoteAuthToken).filter(ub.RemoteAuthToken.user_id == user_id)\
         .filter(ub.RemoteAuthToken.token_type==1).delete()

--- a/cps/metadata_provider/comicvine.py
+++ b/cps/metadata_provider/comicvine.py
@@ -57,7 +57,7 @@ class ComicVine(Metadata):
                 result.raise_for_status()
             except Exception as e:
                 log.warning(e)
-                return None
+                return []
             for result in result.json()["results"]:
                 match = self._parse_search_result(
                     result=result, generic_cover=generic_cover, locale=locale

--- a/cps/metadata_provider/douban.py
+++ b/cps/metadata_provider/douban.py
@@ -155,7 +155,7 @@ class Douban(Metadata):
             r.raise_for_status()
         except Exception as e:
             log.warning(e)
-            return None
+            return []
 
         match = MetaRecord(
             id=id,

--- a/cps/oauth_bb.py
+++ b/cps/oauth_bb.py
@@ -134,6 +134,14 @@ def bind_oauth_or_register(provider_id, provider_user_id, redirect_url, provider
         oauth_entry = query.first()
         # already bind with user, just login
         if oauth_entry.user:
+            # If a user is already logged in and it's a different account, reject the link
+            # to prevent account takeover via shared OAuth identities
+            if current_user and current_user.is_authenticated and oauth_entry.user_id != current_user.id:
+                flash(_("This %(oauth)s account is already linked to a different user",
+                        oauth=provider_name), category="error")
+                log.warning("User %s tried to link OAuth account already bound to user %s",
+                            current_user.id, oauth_entry.user_id)
+                return redirect(url_for('web.profile'))
             login_user(oauth_entry.user)
             log.debug("You are now logged in as: '%s'", oauth_entry.user.name)
             flash(_("Success! You are now logged in as: %(nickname)s", nickname=oauth_entry.user.name),

--- a/cps/services/goodreads_support.py
+++ b/cps/services/goodreads_support.py
@@ -92,7 +92,7 @@ class my_GoodreadsRequest(GoodreadsRequest):
         if resp.status_code != 200:
             raise GoodreadsRequestException(resp.reason, self.path)
         if self.req_format == 'xml':
-            root = etree.fromstring(resp.content)
+            root = etree.fromstring(resp.content, parser=etree.XMLParser(resolve_entities=False, no_network=True))
             data_dict = etree_to_dict(root)
 
             return data_dict['GoodreadsResponse']

--- a/cps/services/simpleldap.py
+++ b/cps/services/simpleldap.py
@@ -31,6 +31,16 @@ except ImportError:
 log = logger.create()
 
 
+def _escape_ldap_filter(s):
+    """Escape special characters for safe use in LDAP filter strings (RFC 4515)."""
+    s = s.replace('\\', '\\5c')
+    s = s.replace('*', '\\2a')
+    s = s.replace('(', '\\28')
+    s = s.replace(')', '\\29')
+    s = s.replace('\x00', '\\00')
+    return s
+
+
 class LDAPLogger(object):
 
     @staticmethod
@@ -148,9 +158,11 @@ def bind_user(username, password):
 
     :returns: True if login succeeded, False if login failed, None if server unavailable.
     '''
+    # Escape LDAP special characters to prevent LDAP injection in search filters
+    safe_username = _escape_ldap_filter(username)
     try:
-        if _ldap.get_object_details(username):
-            result = _ldap.bind_user(username, password)
+        if _ldap.get_object_details(safe_username):
+            result = _ldap.bind_user(safe_username, password)
             log.debug("LDAP login '%s': %r", username, result)
             return result is not None, None
         return None, None       # User not found

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -308,6 +308,9 @@ def order_shelf(shelf_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
     if shelf and check_shelf_view_permissions(shelf):
         if request.method == "POST":
+            if not check_shelf_edit_permissions(shelf):
+                flash(_("Sorry you are not allowed to edit this shelf"), category="error")
+                return redirect(url_for('web.index'))
             to_save = request.form.to_dict()
             books_in_shelf = ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).order_by(
                 ub.BookShelf.order.asc()).all()

--- a/cps/templates/basic_detail.html
+++ b/cps/templates/basic_detail.html
@@ -31,7 +31,7 @@
 <h2>Details</h2>
 
 {% if entry.series|length > 0 %}
-  <p>{{ _("Book %(index)s of %(range)s", index=entry.series_index | formatfloat(2), range=(entry.series[0].name)|safe) }}</p>
+  <p>{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=entry.series[0].name|e) }}</p>
 {% endif %}
 
 {% if entry.languages|length > 0 %}

--- a/cps/templates/basic_detail.html
+++ b/cps/templates/basic_detail.html
@@ -74,7 +74,7 @@
 {% if entry.comments|length > 0 and entry.comments[0].text|length > 0 %}
     <div>
         <h2 id="decription">{{ _('Description:') }}</h2>
-        {{ entry.comments[0].text|safe }}
+        {{ entry.comments[0].text|clean_string|safe }}
     </div>
 {% endif %}
 </div>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -284,7 +284,7 @@
             {% if entry.comments|length > 0 and entry.comments[0].text|length > 0 %}
                 <div class="comments">
                     <h3 id="decription">{{ _('Description:') }}</h3>
-                    {{ entry.comments[0].text|safe }}
+                    {{ entry.comments[0].text|clean_string|safe }}
                 </div>
             {% endif %}
 

--- a/cps/templates/listenmp3.html
+++ b/cps/templates/listenmp3.html
@@ -175,7 +175,7 @@
       {% if entry.comments|length > 0 and entry.comments[0].text|length > 0%}
         <div class="comments">
             <h3 id="decription">{{_('Description:')}}</h3>
-            {{entry.comments[0].text|safe}}
+            {{entry.comments[0].text|clean_string|safe}}
         </div>
       {% endif %}
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -842,7 +842,8 @@ def list_books():
     order = request.args.get("order", "").lower()
     state = None
     join = tuple()
-
+    if not order in ["asc", "desc", ""]:
+        order = "asc"
     if sort_param == "state":
         state = json.loads(request.args.get("state", "[]"))
     elif sort_param == "tags":

--- a/cps/web.py
+++ b/cps/web.py
@@ -1195,7 +1195,9 @@ def get_robots():
 @viewer_required
 def serve_book(book_id, book_format, anyname):
     book_format = book_format.split(".")[0]
-    book = calibre_db.get_book(book_id)
+    book = calibre_db.get_filtered_book(book_id)
+    if not book:
+        return "File not in Database"
     data = calibre_db.get_book_format(book_id, book_format.upper())
     if not data:
         return "File not in Database"


### PR DESCRIPTION
This PR includes several critical security enhancements, bug fixes, and general stability improvements.

Security Fixes:
- Patched multiple vulnerabilities including SQLi via dbpath ([b5da0df](https://github.com/janeczku/calibre-web/commit/b5da0df4)), LDAP injection ([cde3888](https://github.com/janeczku/calibre-web/commit/cde3888e)), and XXE in epub/fb2/goodreads APIs ([224915b](https://github.com/janeczku/calibre-web/commit/224915bb)).
- Resolved access bypass on /show/ ([8477731](https://github.com/janeczku/calibre-web/commit/84777319)) and prevented unauthorized shelf editing ([c451daa](https://github.com/janeczku/calibre-web/commit/c451daad)).
- Fixed an IDOR in Kobo tokens ([d598054](https://github.com/janeczku/calibre-web/commit/d5980541)) and prevented OAuth relinking ([387678a](https://github.com/janeczku/calibre-web/commit/387678a7)).
- Stopped credential leakage in debug_info ([d85bef6](https://github.com/janeczku/calibre-web/commit/d85bef6c)) and applied sane permissions to the encryption key file ([0959f84](https://github.com/janeczku/calibre-web/commit/0959f84f)).

Bug Fixes & Stability:
- Fixed the OPDS feed to ensure atom:updated correctly reflects the last modification date ([ab17992](https://github.com/janeczku/calibre-web/commit/ab17992e)).
- Resolved crashes during metadata searches when ComicVine or Douban returns None ([0ca6e86](https://github.com/janeczku/calibre-web/commit/0ca6e861)).
- Improved error handling for sorting parameters ([0ed4d81](https://github.com/janeczku/calibre-web/commit/0ed4d81d)) and series display in the basic view ([0887789](https://github.com/janeczku/calibre-web/commit/08877896)).
- Fixed a type condition issue in gdrive.py ([8ad9f4e](https://github.com/janeczku/calibre-web/commit/8ad9f4e3)) and ensured strings in comments are cleaned before displaying ([7c715f3](https://github.com/janeczku/calibre-web/commit/7c715f34)).
